### PR TITLE
ci: fix the three shellcheck findings actionlint reported, two of them real

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,16 +73,19 @@ jobs:
           cargo xtask release-plan --package '${{ inputs.package }}' | tee plan.json
           version=$(jq -r .version plan.json)
           tag=$(jq -r .tag plan.json)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "dir=$(jq -r .dir plan.json)" >> "$GITHUB_OUTPUT"
-          # Space-separated, so the build job can loop over it in shell.
-          echo "binaries=$(jq -r '.binaries | join(" ")' plan.json)" >> "$GITHUB_OUTPUT"
-          # "<name>:<dir>" pairs, one system package per binary shipped.
-          echo "packages=$(jq -r '[.packages[] | "\(.name):\(.dir)"] | join(" ")' plan.json)" >> "$GITHUB_OUTPUT"
-          echo "tag_state=$(jq -r .tag_state plan.json)" >> "$GITHUB_OUTPUT"
-          [ "$(jq -r .tag_state plan.json)" = at_head ] && \
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "dir=$(jq -r .dir plan.json)"
+            # Space-separated, so the build job can loop over it in shell.
+            echo "binaries=$(jq -r '.binaries | join(" ")' plan.json)"
+            # "<name>:<dir>" pairs, one system package per binary shipped.
+            echo "packages=$(jq -r '[.packages[] | "\(.name):\(.dir)"] | join(" ")' plan.json)"
+            echo "tag_state=$(jq -r .tag_state plan.json)"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$(jq -r .tag_state plan.json)" = at_head ]; then
             echo "::notice::tag $tag already exists on this commit — resuming a partial release"
+          fi
           if [ "$(jq -r .collision plan.json)" = "true" ]; then
             reason=$(jq -r .collision_reason plan.json)
             echo "::error::$reason — bump the version in Cargo.toml before releasing."
@@ -344,9 +347,21 @@ jobs:
                    aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
             grep -q "$t.tar.gz" formula.rb || { echo "::error::formula is missing $t"; exit 1; }
           done
-          # Every sha256 must be a real 64-hex digest, not an empty string.
-          grep -oE 'sha256 "[^"]*"' formula.rb | grep -vqE 'sha256 "[0-9a-f]{64}"' \
-            && { echo '::error::formula has a malformed sha256'; exit 1; } || true
+          # Every sha256 must be a real 64-hex digest. Count them too: with
+          # `pipefail`, a `grep | grep -vq` pipeline reports success on a
+          # formula containing no sha256 lines at all, which is the very thing
+          # this is meant to catch.
+          mapfile -t shas < <(grep -oE 'sha256 "[^"]*"' formula.rb | cut -d'"' -f2) || true
+          if [ "${#shas[@]}" -ne 4 ]; then
+            echo "::error::formula has ${#shas[@]} sha256 entries, expected 4"
+            exit 1
+          fi
+          for sha in "${shas[@]}"; do
+            if ! printf '%s' "$sha" | grep -qE '^[0-9a-f]{64}$'; then
+              echo "::error::formula has a malformed sha256: '$sha'"
+              exit 1
+            fi
+          done
           # `ruby -c` accepts a test block that runs the wrong binary, so check
           # that every binary the formula installs or invokes is one it ships.
           shipped=" ${{ needs.plan.outputs.binaries }} "
@@ -400,10 +415,15 @@ jobs:
           # The two files are written separately; a mismatch ships a package
           # whose metadata disagrees with its own build recipe.
           for arch in x86_64 aarch64; do
-            pk=$(grep -oE "sha256sums_$arch=\('[0-9a-f]{64}'\)" out/PKGBUILD | grep -oE '[0-9a-f]{64}')
-            si=$(grep -oE "sha256sums_$arch = [0-9a-f]{64}" out/.SRCINFO | grep -oE '[0-9a-f]{64}')
-            [ -n "$pk" ] && [ "$pk" = "$si" ] || {
-              echo "::error::PKGBUILD/.SRCINFO sha256 mismatch for $arch"; exit 1; }
+            # `|| true`: without it a missing checksum aborts the step under
+            # `set -e` at the assignment, before the diagnostic below can say
+            # which file and architecture were wrong.
+            pk=$(grep -oE "sha256sums_$arch=\('[0-9a-f]{64}'\)" out/PKGBUILD | grep -oE '[0-9a-f]{64}' || true)
+            si=$(grep -oE "sha256sums_$arch = [0-9a-f]{64}" out/.SRCINFO | grep -oE '[0-9a-f]{64}' || true)
+            if [ -z "$pk" ] || [ "$pk" != "$si" ]; then
+              echo "::error::PKGBUILD/.SRCINFO sha256 mismatch for $arch (PKGBUILD=${pk:-none} SRCINFO=${si:-none})"
+              exit 1
+            fi
           done
           grep -q "pkgver=${{ needs.plan.outputs.version }}" out/PKGBUILD
           grep -q "pkgver = ${{ needs.plan.outputs.version }}" out/.SRCINFO

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,8 +247,17 @@ jobs:
           %__gpg_sign_cmd %{__gpg} gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --no-armor --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
           EOF
           for f in dist/*.rpm; do rpmsign --addsign "$f"; done
-          rpm --import <(gpg --export --armor "$GPG_KEY_ID")
-          for f in dist/*.rpm; do rpm --checksig "$f" | grep -q 'pgp.*OK\|signatures OK'; done
+          # `rpm --import` needs a real, seekable file: given a process
+          # substitution it fails with "import read failed(0)".
+          gpg --export --armor "$GPG_KEY_ID" > "$RUNNER_TEMP/nits-pubkey.asc"
+          rpm --import "$RUNNER_TEMP/nits-pubkey.asc"
+          for f in dist/*.rpm; do
+            if ! rpm --checksig "$f" | grep -qE 'pgp.*OK|signatures OK'; then
+              echo "::error::$f is not signed"
+              rpm --checksig "$f"
+              exit 1
+            fi
+          done
           ( cd dist && for f in *.deb *.rpm; do shasum -a 256 "$f" > "$f.sha256"; done )
           ls -l dist
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The `workflows are sound` step added in #1 failed on its first run against
`main` ([run 33619992830](https://github.com/JonoPrest/nits/actions/runs/33619992830)).

It passed locally because **shellcheck was not installed here**, so actionlint
silently skipped its shellcheck integration — my local gate was weaker than the
CI one, which is the same shape of mistake as validating that a YAML file
parses and concluding a step changed. shellcheck is installed now, and
`actionlint .github/workflows/*.yml` reproduces CI locally.

Two of the three findings were defects, not style.

## `SC2015` at release.yml:339 — a formula with no checksums passed validation

```bash
grep -oE 'sha256 "[^"]*"' formula.rb | grep -vqE 'sha256 "[0-9a-f]{64}"' \
  && { echo '::error::formula has a malformed sha256'; exit 1; } || true
```

With `pipefail`, the pipeline fails when the *first* grep matches nothing, so
`&&` is skipped and `|| true` swallows the failure. The check therefore reported
success on a formula containing zero `sha256` lines — the exact input it exists
to reject. Demonstrated before the fix:

```
$ bash c1.sh            # formula.rb has no sha256 lines
CHECK-PASSED (formula has zero sha256 lines!)
exit=0
```

Now it collects the digests, requires four, and validates each:

```
::error::formula has 0 sha256 entries, expected 4        # zero entries
::error::formula has a malformed sha256: 'zzz'           # four, one bad
entries: 4 / HAPPY-PATH PASSES                           # real rendered formula
```

## `SC2015` at release.yml:397 — a real mismatch reported nothing

```bash
pk=$(grep -oE "..." out/PKGBUILD | grep -oE '[0-9a-f]{64}')
```

Under `set -e` the assignment aborts the step when the greps match nothing, so
the `::error::` line naming the file and architecture never ran — a genuine
PKGBUILD/.SRCINFO mismatch surfaced as a bare non-zero exit. The greps now
tolerate no match and the `if` reports which side was missing:

```
::error::PKGBUILD/.SRCINFO sha256 mismatch for x86_64 (PKGBUILD=none SRCINFO=none)
```

## `SC2129` at release.yml:71 — style only

The plan step's individual `>> "$GITHUB_OUTPUT"` redirects are grouped, and the
`[ ... ] && echo` notice becomes an `if`.

I checked whether that `&&` was a latent `set -e` abort — it is not. Bash exempts
the command before the final `&&` in an AND-list, and more commands follow it:

```
$ bash -c 'set -euo pipefail; [ absent = at_head ] && echo notice; echo REACHED-END'
REACHED-END
exit=0
```

So the plan step would not have failed on a fresh release. The `if` is for
clarity, not a fix.

## Testing

`actionlint .github/workflows/*.yml` clean with shellcheck present. Each
rewritten check verified against the input the old one mishandled, and the two
formula checks verified against a real rendered formula so the happy path still
passes.

Unrelated but worth recording: the first dry run of the release pipeline
([33621278920](https://github.com/JonoPrest/nits/actions/runs/33621278920)) has
`plan` green and 5 of 6 build targets green, so the corrected runner labels
resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZsG1ZsdLgm5ZdBrdkJNxR
