### PR TITLE
ci: split into independent jobs, fix cache handling, check ReScript formatting

### DIFF
--- a/.github/actions/web-bundle/action.yml
+++ b/.github/actions/web-bundle/action.yml
@@ -1,0 +1,23 @@
+name: web bundle
+description: >
+  Install the tauri system libraries and build the web bundle that
+  nits-client-tauri (`generate_context!`) and nits-client-web (`include_dir!`)
+  embed at compile time. Needed by any job that compiles those two crates.
+runs:
+  using: composite
+  steps:
+    - name: tauri system libraries
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 11
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 24
+        cache: pnpm
+        cache-dependency-path: ui/pnpm-lock.yaml
+    - name: build the web bundle
+      shell: bash
+      working-directory: ui
+      run: pnpm install --frozen-lockfile && pnpm build

--- a/.github/actions/web-bundle/action.yml
+++ b/.github/actions/web-bundle/action.yml
@@ -9,10 +9,10 @@ runs:
     - name: tauri system libraries
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
       with:
         version: 11
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: 24
         cache: pnpm

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,17 +11,27 @@ on:
     # explicitly, adding the label would not trigger anything.
     types: [opened, reopened, synchronize, labeled]
 
-concurrency:
-  group: bench-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   bench:
     name: benchmark triggers
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'perf')
+    # On `labeled`, gate on the label that was just added: otherwise, once a PR
+    # carries `perf`, adding any *other* label satisfies a whole-label-set check
+    # and starts another release build. Every other activity type checks the
+    # full set, since no single label is being added.
+    if: >-
+      github.event_name == 'push'
+      || (github.event.action == 'labeled' && github.event.label.name == 'perf')
+      || (github.event.action != 'labeled'
+          && contains(github.event.pull_request.labels.*.name, 'perf'))
+    # Job-level, not workflow-level: workflow concurrency is applied before a
+    # job's `if` is evaluated, so a run that is going to skip would still cancel
+    # a benchmark already in flight.
+    concurrency:
+      group: bench-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,33 @@
+# Benchmarks are a regression *trigger*, not a correctness gate, and cost a
+# whole release-profile build of the workspace. They live in their own workflow
+# so that opting a PR in does not re-run every other CI job, and so `labeled`
+# can be an activity type here without making every label change re-run CI.
+name: bench
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # `labeled` is not one of the default activity types; without naming them
+    # explicitly, adding the label would not trigger anything.
+    types: [opened, reopened, synchronize, labeled]
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench:
+    name: benchmark triggers
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'perf')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # nits-review-core and nitsd pull in neither tauri nor the web bundle.
+      - run: NITS_BENCH_FILES=2000 cargo bench -p nits-review-core -p nitsd

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,15 +1,12 @@
 # Benchmarks are a regression *trigger*, not a correctness gate, and cost a
-# whole release-profile build of the workspace. They live in their own workflow
-# so that opting a PR in does not re-run every other CI job, and so `labeled`
-# can be an activity type here without making every label change re-run CI.
+# whole release-profile build of the workspace. They run on main only, never in
+# PR CI. `workflow_dispatch` is the escape hatch for checking a branch by hand
+# before merging it.
 name: bench
 on:
   push:
     branches: [main]
-  pull_request:
-    # `labeled` is not one of the default activity types; without naming them
-    # explicitly, adding the label would not trigger anything.
-    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,22 +14,10 @@ env:
 jobs:
   bench:
     name: benchmark triggers
-    # On `labeled`, gate on the label that was just added: otherwise, once a PR
-    # carries `perf`, adding any *other* label satisfies a whole-label-set check
-    # and starts another release build. Every other activity type checks the
-    # full set, since no single label is being added.
-    if: >-
-      github.event_name == 'push'
-      || (github.event.action == 'labeled' && github.event.label.name == 'perf')
-      || (github.event.action != 'labeled'
-          && contains(github.event.pull_request.labels.*.name, 'perf'))
-    # Job-level, not workflow-level: workflow concurrency is applied before a
-    # job's `if` is evaluated, so a run that is going to skip would still cancel
-    # a benchmark already in flight.
+    runs-on: ubuntu-latest
     concurrency:
       group: bench-${{ github.ref }}
       cancel-in-progress: true
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
+      - run: pnpm rescript format --check
       - run: pnpm rescript
       - run: pnpm test
       - run: pnpm vite build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,34 +29,50 @@ jobs:
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
 
-  lint:
-    name: fmt, clippy, wasm
+  # Needs rustfmt and nothing else — no cache, no toolchain build, no bundle.
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      # rust-cache adds the job id to the key by default, so each of these
+      # jobs gets its own cache without an explicit `key`.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Caches are branch-scoped and PR branches are evicted quickly, so
+          # only main's cache is worth keeping; PRs restore from it.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # Only clippy needs these: it is the job that compiles the tauri and
+      # web crates.
+      - uses: ./.github/actions/web-bundle
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  # nits-protocol and nits-client-core are sans-I/O and pull in neither tauri
+  # nor the embedded bundle, so this needs no web-bundle setup.
+  wasm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-          components: clippy, rustfmt
-      # Per-job cache key: this job builds check artifacts, `test` builds dev
-      # with codegen and `bench` builds release. One shared cache would have
-      # them overwriting each other's profile on every run.
       - uses: Swatinem/rust-cache@v2
         with:
-          key: lint
-          # A single lint failure on main would otherwise leave main with no
-          # cache at all, and every PR branched from it then builds cold.
-          cache-on-failure: true
-          # Caches are branch-scoped and PR branches are evicted quickly, so
-          # only main's cache is worth keeping; PRs restore from it.
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: ./.github/actions/web-bundle
-      - run: cargo fmt --all --check
-      - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo check -p nits-protocol -p nits-client-core --target wasm32-unknown-unknown
 
   test:
-    name: tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -64,34 +80,11 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
-          key: test
-          # A single lint failure on main would otherwise leave main with no
-          # cache at all, and every PR branched from it then builds cold.
-          cache-on-failure: true
-          # Caches are branch-scoped and PR branches are evicted quickly, so
-          # only main's cache is worth keeping; PRs restore from it.
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/web-bundle
       - run: cargo nextest run --workspace
       - name: fixtures are up to date
         run: cargo xtask fixtures && git diff --exit-code -- fixtures
-
-  # Benchmarks are a regression *trigger*, not a correctness gate, and cost a
-  # whole release-profile build of the workspace. Run them on main, and on a
-  # PR only when it is labelled `perf`.
-  bench:
-    name: benchmark triggers
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'perf')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: bench
-          cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: NITS_BENCH_FILES=2000 cargo bench -p nits-review-core -p nitsd
 
   ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: scripts and workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: release scripts are sound
         run: shellcheck scripts/*.sh
       # The release workflow is only ever exercised by hand, so lint it here:
@@ -33,7 +33,7 @@ jobs:
     name: fmt, clippy, wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -59,7 +59,7 @@ jobs:
     name: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
@@ -84,7 +84,7 @@ jobs:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'perf')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -99,11 +99,11 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,32 +4,21 @@ on:
     branches: [main]
   pull_request:
 
+# A superseded run tells you nothing; let a new push cancel it.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  rust:
+  # Cheap, no Rust toolchain: fails in seconds rather than behind a build.
+  scripts:
+    name: scripts and workflows
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-          components: clippy, rustfmt
-      - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
-      - name: tauri system libraries (nits-client-tauri)
-        run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
-      # `tauri::generate_context!` and nits-client-web's `include_dir!` embed
-      # `crates/nits-client-web/dist` at compile time; `pnpm build` writes it.
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: ui/pnpm-lock.yaml
-      - name: build the web bundle the Rust crates embed
-        working-directory: ui
-        run: pnpm install --frozen-lockfile && pnpm build
       - name: release scripts are sound
         run: shellcheck scripts/*.sh
       # The release workflow is only ever exercised by hand, so lint it here:
@@ -39,14 +28,70 @@ jobs:
         run: |
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
+
+  lint:
+    name: fmt, clippy, wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy, rustfmt
+      # Per-job cache key: this job builds check artifacts, `test` builds dev
+      # with codegen and `bench` builds release. One shared cache would have
+      # them overwriting each other's profile on every run.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: lint
+          # A single lint failure on main would otherwise leave main with no
+          # cache at all, and every PR branched from it then builds cold.
+          cache-on-failure: true
+          # Caches are branch-scoped and PR branches are evicted quickly, so
+          # only main's cache is worth keeping; PRs restore from it.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: ./.github/actions/web-bundle
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo check -p nits-protocol -p nits-client-core --target wasm32-unknown-unknown
+
+  test:
+    name: tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: test
+          # A single lint failure on main would otherwise leave main with no
+          # cache at all, and every PR branched from it then builds cold.
+          cache-on-failure: true
+          # Caches are branch-scoped and PR branches are evicted quickly, so
+          # only main's cache is worth keeping; PRs restore from it.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: ./.github/actions/web-bundle
       - run: cargo nextest run --workspace
-      - name: benchmark triggers (small scale)
-        run: NITS_BENCH_FILES=2000 cargo bench -p nits-review-core -p nitsd
       - name: fixtures are up to date
         run: cargo xtask fixtures && git diff --exit-code -- fixtures
+
+  # Benchmarks are a regression *trigger*, not a correctness gate, and cost a
+  # whole release-profile build of the workspace. Run them on main, and on a
+  # PR only when it is labelled `perf`.
+  bench:
+    name: benchmark triggers
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'perf')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: bench
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: NITS_BENCH_FILES=2000 cargo bench -p nits-review-core -p nitsd
 
   ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       packages: ${{ steps.plan.outputs.packages }}
       tag_state: ${{ steps.plan.outputs.tag_state }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # tags, so the collision check can see them
       - uses: dtolnay/rust-toolchain@stable
@@ -133,7 +133,7 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -167,7 +167,7 @@ jobs:
           # shasum is the one checksum tool present on both runners.
           ( cd dist && shasum -a 256 "$name.tar.gz" > "$name.tar.gz.sha256" )
           echo "name=$name" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.tarball.outputs.name }}
           path: |
@@ -189,14 +189,14 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deb,cargo-generate-rpm
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.package }}-${{ needs.plan.outputs.version }}-${{ matrix.target }}
           path: incoming
@@ -260,7 +260,7 @@ jobs:
           done
           ( cd dist && for f in *.deb *.rpm; do shasum -a 256 "$f" > "$f.sha256"; done )
           ls -l dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: linux-packages-${{ matrix.arch }}
           path: dist/*
@@ -273,8 +273,8 @@ jobs:
     if: always() && needs.build.result == 'success' && needs.linux-packages.result != 'failure'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           path: incoming
           merge-multiple: true
@@ -305,7 +305,7 @@ jobs:
           else
             git push origin "$tag"
           fi
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         if: '!inputs.dry_run'
         with:
           tag_name: ${{ needs.plan.outputs.tag }}
@@ -319,7 +319,7 @@ jobs:
     if: inputs.crates_io && !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: publish the dependency closure in order
@@ -333,8 +333,8 @@ jobs:
     if: inputs.homebrew && !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           path: incoming
           merge-multiple: true
@@ -402,8 +402,8 @@ jobs:
     if: inputs.aur && !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           path: incoming
           merge-multiple: true
@@ -475,8 +475,8 @@ jobs:
       group: linux-repo
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           path: incoming
           merge-multiple: true

--- a/ui/__tests__/Components_test.res
+++ b/ui/__tests__/Components_test.res
@@ -13,31 +13,37 @@ let kebab = (name: string) =>
 
 describe("Row", () => {
   Fixtures.variants("protocol", "Row")->Array.forEach(v => {
-    [View.Layout.Unified, Split]->Array.forEach(layout => {
-      let layoutName = layout == Unified ? "Unified" : "Split"
-      test(`renders ${v} (${layoutName}) with its semantic class`, () => {
-        let row = Fixtures.parse(Render.Row.schema, "protocol", "Row", v)
-        let {container} = render(
-          <Row row layout index=3 focused={v == "Added"} threads={v == "Modified" ? 2 : 0} />,
+    [View.Layout.Unified, Split]->Array.forEach(
+      layout => {
+        let layoutName = layout == Unified ? "Unified" : "Split"
+        test(
+          `renders ${v} (${layoutName}) with its semantic class`,
+          () => {
+            let row = Fixtures.parse(Render.Row.schema, "protocol", "Row", v)
+            let {container} = render(
+              <Row row layout index=3 focused={v == "Added"} threads={v == "Modified" ? 2 : 0} />,
+            )
+            let el =
+              Element.querySelector(container, "[role=\"row\"]")->Nullable.toOption->Option.getExn
+            expect(Element.className(el))->toContain("row-" ++ kebab(v))
+            expect(Element.className(el))->toContain(layout == Split ? "row-split" : "row-unified")
+            expect(Element.getAttribute(el, "data-row-index"))->toEqual(Nullable.make("3"))
+            expect(Element.hasAttribute(el, "data-focused"))->toBe(v == "Added")
+            if v == "Modified" {
+              expect(Element.querySelector(el, ".row-threads"))->not_->toBeNull
+              expect(Element.querySelector(el, ".span-keyword"))->not_->toBeNull
+              expect(Element.querySelector(el, ".cell-changed"))->not_->toBeNull
+            }
+
+            // Split layout always shows both sides for line rows.
+            if ["Context", "Removed", "Added", "Modified"]->Array.includes(v) && layout == Split {
+              expect(Element.querySelector(el, ".cell-left"))->not_->toBeNull
+              expect(Element.querySelector(el, ".cell-right"))->not_->toBeNull
+            }
+          },
         )
-        let el =
-          Element.querySelector(container, "[role=\"row\"]")->Nullable.toOption->Option.getExn
-        expect(Element.className(el))->toContain("row-" ++ kebab(v))
-        expect(Element.className(el))->toContain(layout == Split ? "row-split" : "row-unified")
-        expect(Element.getAttribute(el, "data-row-index"))->toEqual(Nullable.make("3"))
-        expect(Element.hasAttribute(el, "data-focused"))->toBe(v == "Added")
-        if v == "Modified" {
-          expect(Element.querySelector(el, ".row-threads"))->not_->toBeNull
-          expect(Element.querySelector(el, ".span-keyword"))->not_->toBeNull
-          expect(Element.querySelector(el, ".cell-changed"))->not_->toBeNull
-        }
-        // Split layout always shows both sides for line rows.
-        if ["Context", "Removed", "Added", "Modified"]->Array.includes(v) && layout == Split {
-          expect(Element.querySelector(el, ".cell-left"))->not_->toBeNull
-          expect(Element.querySelector(el, ".cell-right"))->not_->toBeNull
-        }
-      })
-    })
+      },
+    )
   })
 })
 
@@ -100,11 +106,7 @@ describe("InlineThread", () => {
     // While a reply is being written the composer replaces the actions.
     rerender(
       <InlineThread
-        thread
-        focused=true
-        index=3
-        composer={<div> {React.string("the composer")} </div>}
-        dispatch
+        thread focused=true index=3 composer={<div> {React.string("the composer")} </div>} dispatch
       />,
     )
     expect(Screen.getByText("the composer"))->toBeTruthy
@@ -175,18 +177,20 @@ describe("Tree", () => {
     expect(Element.hasAttribute(items->Array.getUnsafe(2), "data-focused"))->toBe(true)
     FireEvent.click(items->Array.getUnsafe(2))
     let calls = mock(dispatch).calls
-    let opened = calls->Array.some(args =>
-      switch args->Array.getUnsafe(0) {
-      | Action.Viewport(_) => true
-      | _ => false
-      }
+    let opened = calls->Array.some(
+      args =>
+        switch args->Array.getUnsafe(0) {
+        | Action.Viewport(_) => true
+        | _ => false
+        },
     )
     expect(opened)->toBe(true)
     FireEvent.click(items->Array.getUnsafe(1))
     let calls = mock(dispatch).calls
-    let focused = calls->Array.some(args =>
-      args->Array.getUnsafe(0) == Action.SetFocus({focus: Tree({index: 1})})
-    )
+    let focused =
+      calls->Array.some(
+        args => args->Array.getUnsafe(0) == Action.SetFocus({focus: Tree({index: 1})}),
+      )
     expect(focused)->toBe(true)
     switch calls->Array.getUnsafe(Array.length(calls) - 1)->Array.getUnsafe(0) {
     | Action.ToggleDir(_) => ()
@@ -215,7 +219,9 @@ describe("Threads", () => {
     let dispatch = fn()
     let thread = Fixtures.parse(View.ThreadView.schema, "client", "ThreadView", "default")
     let _ = render(
-      <Threads title="Threads" threads=[thread] focus={Thread({index: 0})} indexOffset=0 dispatch />,
+      <Threads
+        title="Threads" threads=[thread] focus={Thread({index: 0})} indexOffset=0 dispatch
+      />,
     )
     FireEvent.click(Screen.getByText("Apply suggestion (a)"))
     // The click also bubbles to the row (SetFocus), so not the last call.
@@ -232,16 +238,19 @@ describe("Threads", () => {
     let dispatch = fn()
     let thread = Fixtures.parse(View.ThreadView.schema, "client", "ThreadView", "default")
     let {container} = render(
-      <Threads title="Threads" threads=[thread] focus={Thread({index: 0})} indexOffset=0 dispatch />,
+      <Threads
+        title="Threads" threads=[thread] focus={Thread({index: 0})} indexOffset=0 dispatch
+      />,
     )
     let bodies = Element.querySelectorAll(container, ".thread-body")
     expect(Array.length(bodies))->toBe(Array.length(thread.comments))
     FireEvent.click(Element.querySelector(container, ".thread-item")->Nullable.getExn)
-    let opened = mock(dispatch).calls->Array.some(args =>
-      switch args->Array.getUnsafe(0) {
-      | Action.Viewport(_) => true
-      | _ => false
-      }
+    let opened = mock(dispatch).calls->Array.some(
+      args =>
+        switch args->Array.getUnsafe(0) {
+        | Action.Viewport(_) => true
+        | _ => false
+        },
     )
     expect(opened)->toBe(true)
     cleanup()
@@ -260,11 +269,12 @@ describe("Palette", () => {
     let hit = cs.hits->Array.getUnsafe(0)
     FireEvent.click(Screen.getByText(hit.path ++ ":" ++ Int.toString(hit.line)))
     let calls = mock(dispatch).calls
-    let jumped = calls->Array.some(args =>
-      switch args->Array.getUnsafe(0) {
-      | Action.Viewport({file}) => file.path == hit.path
-      | _ => false
-      }
+    let jumped = calls->Array.some(
+      args =>
+        switch args->Array.getUnsafe(0) {
+        | Action.Viewport({file}) => file.path == hit.path
+        | _ => false
+        },
     )
     expect(jumped)->toBe(true)
     cleanup()
@@ -288,8 +298,10 @@ describe("Context expanders", () => {
     cleanup()
     let row = Fixtures.parse(Render.Row.schema, "protocol", "Row", "Expander")
     let expand = fn()
-    let _ = render(<Row row layout=Unified index=0 focused=false threads=0 onExpand={() => expand()} />)
-    FireEvent.click(Screen.getByTextRe(%re("/more lines/")))
+    let _ = render(
+      <Row row layout=Unified index=0 focused=false threads=0 onExpand={() => expand()} />,
+    )
+    FireEvent.click(Screen.getByTextRe(/more lines/))
     expect(expand)->toHaveBeenCalled
   })
 })
@@ -305,19 +317,21 @@ describe("Jump to original diff", () => {
       context: Some(Fixtures.parse(Domain.ChangeKind.schema, "protocol", "ChangeKind", "Modified")),
     }
     let _ = render(
-      <Threads title="Threads" threads=[outdated] focus={Thread({index: 0})} indexOffset=0 dispatch />,
+      <Threads
+        title="Threads" threads=[outdated] focus={Thread({index: 0})} indexOffset=0 dispatch
+      />,
     )
     FireEvent.click(Screen.getByText("Open original diff (enter)"))
     expect(dispatch)->toHaveBeenCalledWith(Action.OpenOriginalDiff({threadId: outdated.id}))
     // Clicking the row itself also jumps to the original, not the moved-on diff.
     let calls = mock(dispatch).calls
-    let jumped =
-      calls->Array.every(args =>
+    let jumped = calls->Array.every(
+      args =>
         switch args->Array.getUnsafe(0) {
         | Action.Viewport(_) => false
         | _ => true
-        }
-      )
+        },
+    )
     expect(jumped)->toBe(true)
   })
 
@@ -329,9 +343,7 @@ describe("Jump to original diff", () => {
     )
     expect(Element.querySelector(container, ".original-banner"))->not_->toBeNull
     cleanup()
-    let {container} = render(
-      <DiffView diff=base layout=Unified focus={Diff({row: 0})} dispatch />,
-    )
+    let {container} = render(<DiffView diff=base layout=Unified focus={Diff({row: 0})} dispatch />)
     expect(Element.querySelector(container, ".original-banner"))->toBeNull
   })
 })
@@ -341,7 +353,9 @@ describe("DiffView (viewed)", () => {
     let dispatch = fn()
     let base = Fixtures.parse(View.DiffView.schema, "client", "DiffView", "default")
     let viewed = {...base, viewed: Viewed}
-    let {container} = render(<DiffView diff=viewed layout=Unified focus={Diff({row: 121})} dispatch />)
+    let {container} = render(
+      <DiffView diff=viewed layout=Unified focus={Diff({row: 121})} dispatch />,
+    )
     expect(Element.querySelector(container, ".diff-collapsed"))->not_->toBeNull
     expect(Element.querySelector(container, ".diff-scroll.hidden"))->not_->toBeNull
     FireEvent.click(Screen.getByText("show anyway"))
@@ -369,7 +383,9 @@ describe("RefSpecText", () => {
       WorkingTree({}),
       Head({}),
       Upstream({}),
-    ]->Array.forEach(spec => expect(RefSpecText.parse(RefSpecText.print(spec)))->toEqual(Some(spec)))
+    ]->Array.forEach(
+      spec => expect(RefSpecText.parse(RefSpecText.print(spec)))->toEqual(Some(spec)),
+    )
   })
 })
 
@@ -408,7 +424,7 @@ describe("NewReview (no repos)", () => {
     let dispatch = fn()
     let _ = render(<NewReview workspaces=[] onClose={() => ()} dispatch />)
     expect(Array.length(Screen.queryAllByText("Create")))->toBe(0)
-    let _ = Screen.getByTextRe(%re("/workspace attach/"))
+    let _ = Screen.getByTextRe(/workspace attach/)
     expect(dispatch)->not_->toHaveBeenCalled
   })
 })
@@ -535,18 +551,19 @@ describe("ScopeControl", () => {
     let review = Fixtures.parse(Domain.Review.schema, "protocol", "Review", "default")
     let ws = Fixtures.parse(Domain.Workspace.schema, "protocol", "Workspace", "default")
     let prefs = View.ViewModel.empty.prefs
-    let render_ = (scope, stepper) => render(
-      <ReviewHeader
-        reviews=[review]
-        workspaces=[ws]
-        resolvedTargets=[]
-        openReview=Some(review.id)
-        prefs
-        scope
-        ?stepper
-        dispatch
-      />,
-    )
+    let render_ = (scope, stepper) =>
+      render(
+        <ReviewHeader
+          reviews=[review]
+          workspaces=[ws]
+          resolvedTargets=[]
+          openReview=Some(review.id)
+          prefs
+          scope
+          ?stepper
+          dispatch
+        />,
+      )
     let _ = render_(Domain.DiffScope.All({}), None)
     let all = Screen.getByText("All changes")
     expect(Element.hasAttribute(all, "data-active"))->toBe(true)
@@ -582,12 +599,8 @@ describe("ScopeControl", () => {
 describe("Tabs", () => {
   test("marks the active tab, shows counts, dispatches SetTab on click", () => {
     let dispatch = fn()
-    let chrome: array<View.Hint.t> = [
-      {keys: "2", command: TabConversation, label: "conversation"},
-    ]
-    let {container} = render(
-      <Tabs tab=FilesChanged fileCount=4 threadCount=2 chrome dispatch />,
-    )
+    let chrome: array<View.Hint.t> = [{keys: "2", command: TabConversation, label: "conversation"}]
+    let {container} = render(<Tabs tab=FilesChanged fileCount=4 threadCount=2 chrome dispatch />)
     let tabs = Element.querySelectorAll(container, "[role=\"tab\"]")
     expect(Array.length(tabs))->toBe(3)
     expect(Element.hasAttribute(tabs->Array.getUnsafe(0), "data-active"))->toBe(true)
@@ -612,8 +625,7 @@ describe("Tree (rows)", () => {
     // lib.rs carries +9 −1 and a 2-thread badge (from the fixture).
     expect(Screen.getByText("+9"))->toBeTruthy
     expect(Screen.getByText("−1"))->toBeTruthy
-    let badge =
-      Element.querySelector(container, ".tree-threads")->Nullable.toOption->Option.getExn
+    let badge = Element.querySelector(container, ".tree-threads")->Nullable.toOption->Option.getExn
     expect(Element.textContent(badge))->toBe("2")
     // Clicking a file opens it.
     FireEvent.click(Screen.getByText("lib.rs"))

--- a/ui/__tests__/Fixtures.res
+++ b/ui/__tests__/Fixtures.res
@@ -10,8 +10,10 @@
 let root = join3(dirname, "..", "..")
 
 let json = (set: string, type_: string, name: string): JSON.t =>
-  readFileSync(join4(root, "fixtures", set, type_ ++ "/" ++ name ++ ".json"), "utf8")
-  ->JSON.parseOrThrow
+  readFileSync(
+    join4(root, "fixtures", set, type_ ++ "/" ++ name ++ ".json"),
+    "utf8",
+  )->JSON.parseOrThrow
 
 let parse = (schema: S.t<'a>, set: string, type_: string, name: string): 'a =>
   S.parseJsonOrThrow(json(set, type_, name), schema)

--- a/ui/src/App.res
+++ b/ui/src/App.res
@@ -113,7 +113,11 @@ module Shell = {
       <Tree tree=model.tree focus=model.focus ?home dispatch />
     } else {
       <ReviewList
-        reviews=model.reviews workspaces=model.workspaces connection=model.connection focus=model.focus dispatch
+        reviews=model.reviews
+        workspaces=model.workspaces
+        connection=model.connection
+        focus=model.focus
+        dispatch
       />
     }
     // The sidebar auto-expands to fit full file names while the tree is
@@ -129,7 +133,8 @@ module Shell = {
               type_="button"
               className="sidebar-rail"
               title=?{Chrome.tip(model.chrome, ToggleSidebar)}
-              onClick={_ => dispatch(ToggleSidebar({}))}>
+              onClick={_ => dispatch(ToggleSidebar({}))}
+            >
               {React.string("⟩")}
             </button>
           : <aside className={"app-left" ++ (treeFocused ? " app-left-expanded" : "")}>
@@ -142,7 +147,8 @@ module Shell = {
                 type_="button"
                 className="sidebar-collapse"
                 title=?{Chrome.tip(model.chrome, ToggleSidebar)}
-                onClick={_ => dispatch(ToggleSidebar({}))}>
+                onClick={_ => dispatch(ToggleSidebar({}))}
+              >
                 {React.string("⟨ hide")}
               </button>
             </aside>}
@@ -234,9 +240,7 @@ module Shell = {
           }}
         </div>
       </div>
-      <WhichKey
-        pendingKeys=model.pendingKeys pendingLabel=model.pendingLabel hints=model.hints
-      />
+      <WhichKey pendingKeys=model.pendingKeys pendingLabel=model.pendingLabel hints=model.hints />
       <HintBar
         hints=model.hints
         pendingKeys=model.pendingKeys

--- a/ui/src/core/CoreTauri.res
+++ b/ui/src/core/CoreTauri.res
@@ -21,7 +21,10 @@ let errorCommand = "client_error"
 /// Console plus the host log (the console is invisible in a packaged app).
 let reportError = (message: string) => {
   Console.error(message)
-  invoke(errorCommand, JSON.Encode.object(Dict.fromArray([("message", JSON.Encode.string(message))])))
+  invoke(
+    errorCommand,
+    JSON.Encode.object(Dict.fromArray([("message", JSON.Encode.string(message))])),
+  )
   ->Promise.then(_ => Promise.resolve())
   ->Promise.catch(_ => Promise.resolve())
   ->ignore
@@ -32,16 +35,15 @@ let make = (~onError: string => unit=reportError): Core.t => {
   // `listen` registers asynchronously; anything the host emits before it
   // resolves is lost, so `attach` (which makes the host emit every
   // section) waits for it.
-  let listening =
-    listen(viewEvent, ev =>
-      switch Core.patchesOfJson(ev.payload) {
-      | Ok(patches) => Core.Store.apply(store, patches)
-      | Error(e) => onError("view event: " ++ e)
-      }
-    )->Promise.catch(exn => {
-      onError("listen: " ++ Core.message(exn))
-      Promise.resolve(() => ())
-    })
+  let listening = listen(viewEvent, ev =>
+    switch Core.patchesOfJson(ev.payload) {
+    | Ok(patches) => Core.Store.apply(store, patches)
+    | Error(e) => onError("view event: " ++ e)
+    }
+  )->Promise.catch(exn => {
+    onError("listen: " ++ Core.message(exn))
+    Promise.resolve(() => ())
+  })
   {
     dispatch: action => {
       let args = JSON.Encode.object(Dict.fromArray([("action", Core.actionToJson(action))]))

--- a/ui/src/core/CoreWs.res
+++ b/ui/src/core/CoreWs.res
@@ -38,7 +38,10 @@ let make = (~url: string, ~onError: string => unit=e => Console.error(e)): Core.
     Ws.onopen(ws, () => {
       open_ := true
       // Attach first so the full model precedes any queued command's patches.
-      Ws.send(ws, JSON.stringify(JSON.Encode.object(Dict.fromArray([("cmd", JSON.Encode.string("attach"))]))))
+      Ws.send(
+        ws,
+        JSON.stringify(JSON.Encode.object(Dict.fromArray([("cmd", JSON.Encode.string("attach"))]))),
+      )
       let pending = queue.contents
       queue := []
       pending->Array.forEach(text => Ws.send(ws, text))
@@ -81,7 +84,8 @@ let defaultUrl = () => {
   let fromQuery = %raw(`new URLSearchParams(window.location.search).get("ws")`)
   switch fromQuery->Nullable.toOption {
   | Some(url) => url
-  | None => %raw(`(window.location.protocol === "https:" ? "wss://" : "ws://") + window.location.host + "/ws"`)
+  | None =>
+    %raw(`(window.location.protocol === "https:" ? "wss://" : "ws://") + window.location.host + "/ws"`)
   }
 }
 

--- a/ui/src/protocol/Domain.res
+++ b/ui/src/protocol/Domain.res
@@ -56,8 +56,7 @@ module ResolvedSource = {
   @schema @tag("type")
   type t =
     | @as("Commit") Commit({oid: commitOid})
-    | @as("WorkingTree")
-    WorkingTree({dirty: array<string>, branch: @s.null option<string>})
+    | @as("WorkingTree") WorkingTree({dirty: array<string>, branch: @s.null option<string>})
 }
 
 module ResolvedRef = {
@@ -129,7 +128,12 @@ module Anchor = {
   @schema @tag("type")
   type t =
     | @as("Review") Review({})
-    | @as("File") File({@as("repo_id") repoId: repoId, path: string, @as("blob_oid") blobOid: blobOid})
+    | @as("File")
+    File({
+        @as("repo_id") repoId: repoId,
+        path: string,
+        @as("blob_oid") blobOid: blobOid,
+      })
     | @as("Lines")
     Lines({
         @as("repo_id") repoId: repoId,
@@ -266,7 +270,11 @@ module TreeEntry = {
 
 module TreeSnapshot = {
   @schema
-  type t = {@as("repo_id") repoId: repoId, @as("root_oid") rootOid: treeOid, entries: array<TreeEntry.t>}
+  type t = {
+    @as("repo_id") repoId: repoId,
+    @as("root_oid") rootOid: treeOid,
+    entries: array<TreeEntry.t>,
+  }
 }
 
 module TreeDelta = {

--- a/ui/src/protocol/Events.res
+++ b/ui/src/protocol/Events.res
@@ -7,21 +7,42 @@ module EventBody = {
   @schema @tag("type")
   type t =
     | @as("WorkspaceCreated") WorkspaceCreated({workspace: Workspace.t})
-    | @as("WorkspaceUpdated") WorkspaceUpdated({@as("workspace_id") workspaceId: workspaceId, name: string})
+    | @as("WorkspaceUpdated")
+    WorkspaceUpdated({
+        @as("workspace_id") workspaceId: workspaceId,
+        name: string,
+      })
     | @as("RepoAttached") RepoAttached({@as("workspace_id") workspaceId: workspaceId, repo: Repo.t})
     | @as("RepoDetached")
-    RepoDetached({@as("workspace_id") workspaceId: workspaceId, @as("repo_id") repoId: repoId})
+    RepoDetached({
+        @as("workspace_id") workspaceId: workspaceId,
+        @as("repo_id") repoId: repoId,
+      })
     | @as("ReviewCreated") ReviewCreated({review: Review.t})
     | @as("ReviewUpdated")
-    ReviewUpdated({@as("review_id") reviewId: reviewId, title: string, status: ReviewStatus.t})
+    ReviewUpdated({
+        @as("review_id") reviewId: reviewId,
+        title: string,
+        status: ReviewStatus.t,
+      })
     | @as("ReviewDeleted") ReviewDeleted({@as("review_id") reviewId: reviewId})
     | @as("ReviewTargetsResolved")
-    ReviewTargetsResolved({@as("review_id") reviewId: reviewId, targets: array<ResolvedTarget.t>})
+    ReviewTargetsResolved({
+        @as("review_id") reviewId: reviewId,
+        targets: array<ResolvedTarget.t>,
+      })
     | @as("CommentCreated") CommentCreated({comment: Comment.t})
     | @as("CommentEdited")
-    CommentEdited({@as("review_id") reviewId: reviewId, @as("comment_id") commentId: commentId, body: string})
+    CommentEdited({
+        @as("review_id") reviewId: reviewId,
+        @as("comment_id") commentId: commentId,
+        body: string,
+      })
     | @as("CommentDeleted")
-    CommentDeleted({@as("review_id") reviewId: reviewId, @as("comment_id") commentId: commentId})
+    CommentDeleted({
+        @as("review_id") reviewId: reviewId,
+        @as("comment_id") commentId: commentId,
+      })
     | @as("CommentReanchored")
     CommentReanchored({
         @as("review_id") reviewId: reviewId,
@@ -30,9 +51,15 @@ module EventBody = {
         state: CommentState.t,
       })
     | @as("ThreadResolved")
-    ThreadResolved({@as("review_id") reviewId: reviewId, @as("thread_id") threadId: threadId})
+    ThreadResolved({
+        @as("review_id") reviewId: reviewId,
+        @as("thread_id") threadId: threadId,
+      })
     | @as("ThreadUnresolved")
-    ThreadUnresolved({@as("review_id") reviewId: reviewId, @as("thread_id") threadId: threadId})
+    ThreadUnresolved({
+        @as("review_id") reviewId: reviewId,
+        @as("thread_id") threadId: threadId,
+      })
     | @as("FileViewed")
     FileViewed({
         @as("review_id") reviewId: reviewId,
@@ -49,7 +76,11 @@ module EventBody = {
         viewer: Human.t,
       })
     | @as("ReviewRequested")
-    ReviewRequested({@as("review_id") reviewId: reviewId, agent: string, note: string})
+    ReviewRequested({
+        @as("review_id") reviewId: reviewId,
+        agent: string,
+        note: string,
+      })
     | @as("SuggestionApplied")
     SuggestionApplied({
         @as("review_id") reviewId: reviewId,

--- a/ui/src/protocol/Registry.res
+++ b/ui/src/protocol/Registry.res
@@ -82,6 +82,7 @@ let roundtrip = (typeName: string, json: JSON.t): result<JSON.t, string> =>
       let value = S.parseJsonOrThrow(json, schema)
       Ok(S.reverseConvertToJsonOrThrow(value, schema))
     } catch {
-    | exn => Error(JsExn.fromException(exn)->Option.flatMap(JsExn.message)->Option.getOr("unknown error"))
+    | exn =>
+      Error(JsExn.fromException(exn)->Option.flatMap(JsExn.message)->Option.getOr("unknown error"))
     }
   }

--- a/ui/src/protocol/Rpc.res
+++ b/ui/src/protocol/Rpc.res
@@ -28,9 +28,15 @@ module RpcError = {
     | @as("SeqTooOld") SeqTooOld({oldest: seq})
     | @as("Cancelled") Cancelled({})
     | @as("UnsupportedProtocol")
-    UnsupportedProtocol({requested: protocolVersion, supported: array<protocolVersion>})
+    UnsupportedProtocol({
+        requested: protocolVersion,
+        supported: array<protocolVersion>,
+      })
     | @as("VersionMismatch")
-    VersionMismatch({negotiated: protocolVersion, received: protocolVersion})
+    VersionMismatch({
+        negotiated: protocolVersion,
+        received: protocolVersion,
+      })
     | @as("Internal") Internal({message: string})
   @@warning("+27")
 }
@@ -76,8 +82,16 @@ module ViewSection = {
 module Mutation = {
   @schema @tag("type")
   type t =
-    | @as("CreateWorkspace") CreateWorkspace({@as("workspace_id") workspaceId: workspaceId, name: string})
-    | @as("RenameWorkspace") RenameWorkspace({@as("workspace_id") workspaceId: workspaceId, name: string})
+    | @as("CreateWorkspace")
+    CreateWorkspace({
+        @as("workspace_id") workspaceId: workspaceId,
+        name: string,
+      })
+    | @as("RenameWorkspace")
+    RenameWorkspace({
+        @as("workspace_id") workspaceId: workspaceId,
+        name: string,
+      })
     | @as("AttachRepo")
     AttachRepo({
         @as("workspace_id") workspaceId: workspaceId,
@@ -86,7 +100,10 @@ module Mutation = {
         @as("display_name") displayName: string,
       })
     | @as("DetachRepo")
-    DetachRepo({@as("workspace_id") workspaceId: workspaceId, @as("repo_id") repoId: repoId})
+    DetachRepo({
+        @as("workspace_id") workspaceId: workspaceId,
+        @as("repo_id") repoId: repoId,
+      })
     | @as("CreateReview")
     CreateReview({
         @as("review_id") reviewId: reviewId,
@@ -95,7 +112,11 @@ module Mutation = {
         targets: array<ReviewTarget.t>,
       })
     | @as("UpdateReview")
-    UpdateReview({@as("review_id") reviewId: reviewId, title: string, status: ReviewStatus.t})
+    UpdateReview({
+        @as("review_id") reviewId: reviewId,
+        title: string,
+        status: ReviewStatus.t,
+      })
     | @as("DeleteReview") DeleteReview({@as("review_id") reviewId: reviewId})
     | @as("AddComment")
     AddComment({
@@ -115,21 +136,49 @@ module Mutation = {
         body: string,
       })
     | @as("EditComment")
-    EditComment({@as("review_id") reviewId: reviewId, @as("comment_id") commentId: commentId, body: string})
+    EditComment({
+        @as("review_id") reviewId: reviewId,
+        @as("comment_id") commentId: commentId,
+        body: string,
+      })
     | @as("DeleteComment")
-    DeleteComment({@as("review_id") reviewId: reviewId, @as("comment_id") commentId: commentId})
+    DeleteComment({
+        @as("review_id") reviewId: reviewId,
+        @as("comment_id") commentId: commentId,
+      })
     | @as("ResolveThread")
-    ResolveThread({@as("review_id") reviewId: reviewId, @as("thread_id") threadId: threadId})
+    ResolveThread({
+        @as("review_id") reviewId: reviewId,
+        @as("thread_id") threadId: threadId,
+      })
     | @as("UnresolveThread")
-    UnresolveThread({@as("review_id") reviewId: reviewId, @as("thread_id") threadId: threadId})
+    UnresolveThread({
+        @as("review_id") reviewId: reviewId,
+        @as("thread_id") threadId: threadId,
+      })
     | @as("MarkViewed")
-    MarkViewed({@as("review_id") reviewId: reviewId, @as("repo_id") repoId: repoId, path: string})
+    MarkViewed({
+        @as("review_id") reviewId: reviewId,
+        @as("repo_id") repoId: repoId,
+        path: string,
+      })
     | @as("UnmarkViewed")
-    UnmarkViewed({@as("review_id") reviewId: reviewId, @as("repo_id") repoId: repoId, path: string})
+    UnmarkViewed({
+        @as("review_id") reviewId: reviewId,
+        @as("repo_id") repoId: repoId,
+        path: string,
+      })
     | @as("RequestReview")
-    RequestReview({@as("review_id") reviewId: reviewId, agent: string, note: string})
+    RequestReview({
+        @as("review_id") reviewId: reviewId,
+        agent: string,
+        note: string,
+      })
     | @as("ApplySuggestion")
-    ApplySuggestion({@as("review_id") reviewId: reviewId, @as("comment_id") commentId: commentId})
+    ApplySuggestion({
+        @as("review_id") reviewId: reviewId,
+        @as("comment_id") commentId: commentId,
+      })
 }
 
 module Request = {
@@ -151,7 +200,10 @@ module Request = {
     | @as("OpenReview") OpenReview({@as("review_id") reviewId: reviewId, opts: RenderOpts.t})
     | @as("ResolveTargets") ResolveTargets({@as("review_id") reviewId: reviewId})
     | @as("ListCommits")
-    ListCommits({@as("review_id") reviewId: reviewId, @as("repo_id") repoId: repoId})
+    ListCommits({
+        @as("review_id") reviewId: reviewId,
+        @as("repo_id") repoId: repoId,
+      })
     | @as("TreeSnapshot") TreeSnapshot({@as("repo_id") repoId: repoId, @as("ref") ref_: RefSpec.t})
     | @as("FileRender")
     FileRender({
@@ -219,8 +271,7 @@ module StreamItem = {
     | @as("ReviewSnapshot") ReviewSnapshot({snapshot: ReviewSnapshot.t})
     | @as("TreeSnapshot") TreeSnapshot({snapshot: TreeSnapshot.t})
     | @as("Header") Header({header: Render.FileRenderHeader.t})
-    | @as("Chunk")
-    Chunk({@as("repo_id") repoId: repoId, path: string, chunk: Render.RenderChunk.t})
+    | @as("Chunk") Chunk({@as("repo_id") repoId: repoId, path: string, chunk: Render.RenderChunk.t})
 }
 
 module ClientMsg = {

--- a/ui/src/ui/DiffView.res
+++ b/ui/src/ui/DiffView.res
@@ -118,14 +118,15 @@ let make = (
         </div>
       : React.null}
     <div
-      className={"diff-scroll" ++ (collapsed ? " hidden" : "")}
-      ref={ReactDOM.Ref.domRef(scrollRef)}>
+      className={"diff-scroll" ++ (collapsed ? " hidden" : "")} ref={ReactDOM.Ref.domRef(scrollRef)}
+    >
       <div
         className="diff-rows"
         style={{
           height: Int.toString(virtualizer->Virtual.getTotalSize) ++ "px",
           position: "relative",
-        }}>
+        }}
+      >
         {items
         ->Array.map(item => {
           let style: ReactDOM.Style.t = {
@@ -158,7 +159,12 @@ let make = (
                 | _ => React.null
                 }
                 <InlineThread
-                  key=thread.id thread focused={focusedThread == Some(ti)} index=ti composer dispatch
+                  key=thread.id
+                  thread
+                  focused={focusedThread == Some(ti)}
+                  index=ti
+                  composer
+                  dispatch
                 />
               })
               ->React.array}
@@ -178,7 +184,8 @@ let make = (
               ref={ReactDOM.Ref.callbackDomRef(el => {
                 (virtualizer->Virtual.measureElement)(el)
                 None
-              })}>
+              })}
+            >
               inner
             </div>
           Attrs.withData(el, [("data-index", Int.toString(item.index))])

--- a/ui/src/ui/FileDiff.res
+++ b/ui/src/ui/FileDiff.res
@@ -92,56 +92,64 @@ let make = (
     | _ => false
     }
   <section className="file-diff" ariaLabel=diff.file.path ref={ReactDOM.Ref.domRef(sectionRef)}>
-    {Attrs.focused(<header className="file-diff-header">
-      <button
-        type_="button"
-        className="btn btn-ghost file-chevron"
-        title={collapsed ? "expand file section" : "collapse file section"}
-        onClick={_ => dispatch(ToggleFileCollapse({file: diff.file}))}>
-        {React.string(collapsed ? "▸" : "▾")}
-      </button>
-      <span className="file-path mono"> {React.string(diff.file.path)} </span>
-      <button
-        type_="button"
-        className="btn btn-ghost"
-        title="copy file path"
-        onClick={_ => writeText(diff.file.path)}>
-        {React.string("⧉")}
-      </button>
-      stats
-      {diff.fileThreads->Array.length > 0
-        ? <span className="tree-threads"> {React.string(Int.toString(Array.length(diff.fileThreads)))} </span>
-        : React.null}
-      <span className="file-diff-actions">
+    {Attrs.focused(
+      <header className="file-diff-header">
+        <button
+          type_="button"
+          className="btn btn-ghost file-chevron"
+          title={collapsed ? "expand file section" : "collapse file section"}
+          onClick={_ => dispatch(ToggleFileCollapse({file: diff.file}))}
+        >
+          {React.string(collapsed ? "▸" : "▾")}
+        </button>
+        <span className="file-path mono"> {React.string(diff.file.path)} </span>
         <button
           type_="button"
           className="btn btn-ghost"
-          title="comment on this file"
-          onClick={_ => dispatch(CommentFile({file: diff.file}))}>
-          {React.string("💬")}
+          title="copy file path"
+          onClick={_ => writeText(diff.file.path)}
+        >
+          {React.string("⧉")}
         </button>
-        <UI.Button
-          label="expand file"
-          kind=Ghost
-          title="show the whole file as context"
-          onClick={() => dispatch(ExpandContext({file: diff.file, full: true}))}
-        />
-        <label className="chip-check" title="mark viewed (v)">
-          <input
-            type_="checkbox"
-            checked={diff.viewed == Viewed}
-            onChange={_ => {
-              dispatch(
-                diff.viewed == Viewed
-                  ? UnmarkViewed({file: diff.file})
-                  : MarkViewed({file: diff.file}),
-              )
-            }}
+        stats
+        {diff.fileThreads->Array.length > 0
+          ? <span className="tree-threads">
+              {React.string(Int.toString(Array.length(diff.fileThreads)))}
+            </span>
+          : React.null}
+        <span className="file-diff-actions">
+          <button
+            type_="button"
+            className="btn btn-ghost"
+            title="comment on this file"
+            onClick={_ => dispatch(CommentFile({file: diff.file}))}
+          >
+            {React.string("💬")}
+          </button>
+          <UI.Button
+            label="expand file"
+            kind=Ghost
+            title="show the whole file as context"
+            onClick={() => dispatch(ExpandContext({file: diff.file, full: true}))}
           />
-          {React.string("Viewed")}
-        </label>
-      </span>
-    </header>, isOpen && collapsed)}
+          <label className="chip-check" title="mark viewed (v)">
+            <input
+              type_="checkbox"
+              checked={diff.viewed == Viewed}
+              onChange={_ => {
+                dispatch(
+                  diff.viewed == Viewed
+                    ? UnmarkViewed({file: diff.file})
+                    : MarkViewed({file: diff.file}),
+                )
+              }}
+            />
+            {React.string("Viewed")}
+          </label>
+        </span>
+      </header>,
+      isOpen && collapsed,
+    )}
     {collapsed
       ? React.null
       : <div className="file-diff-body" onMouseLeave={_ => setDrag(_ => None)}>
@@ -196,7 +204,8 @@ let make = (
                     }
                   }
                 | None => ()
-                }}>
+                }}
+            >
               rowEl
               {r.threads
               ->Array.filterMap(threadOf)
@@ -230,7 +239,8 @@ let make = (
               onClick={_ => {
                 let from = (rows->Array.getUnsafe(have - 1)).index + 1
                 dispatch(Viewport({file: diff.file, firstRow: from, lastRow: from + 199}))
-              }}>
+              }}
+            >
               {React.string("Load more (" ++ Int.toString(total - have) ++ " rows below)")}
             </button>
           | _ => React.null

--- a/ui/src/ui/HelpOverlay.res
+++ b/ui/src/ui/HelpOverlay.res
@@ -66,7 +66,9 @@ let make = (~help: HelpView.t, ~dispatch: Action.t => unit) => {
               ->Array.filter(matches)
               ->Array.map(e =>
                 <tr key={e.keys ++ e.label} className={e.overridden ? "help-overridden" : ""}>
-                  <td> <UI.Kbd keys=e.keys /> </td>
+                  <td>
+                    <UI.Kbd keys=e.keys />
+                  </td>
                   <td> {React.string(e.label)} </td>
                   <td> {React.string(e.primary ? "★" : "")} </td>
                 </tr>

--- a/ui/src/ui/HintBar.res
+++ b/ui/src/ui/HintBar.res
@@ -38,7 +38,8 @@ let make = (
     </span>
     {leader != "" && !pending
       ? <span className="leader-chip" title={"leader: " ++ leader}>
-          <UI.Kbd keys=leader /> {React.string(" leader")}
+          <UI.Kbd keys=leader />
+          {React.string(" leader")}
         </span>
       : React.null}
     {pending
@@ -53,7 +54,8 @@ let make = (
     {hints
     ->Array.map(h =>
       <span key={h.keys ++ h.label} className="hint">
-        <UI.Kbd keys=h.keys /> {React.string(" " ++ h.label)}
+        <UI.Kbd keys=h.keys />
+        {React.string(" " ++ h.label)}
       </span>
     )
     ->React.array}

--- a/ui/src/ui/InlineThread.res
+++ b/ui/src/ui/InlineThread.res
@@ -12,11 +12,12 @@ let make = (
   ~composer: React.element,
   ~dispatch: Action.t => unit,
 ) => {
-  let flags = [
-    thread.resolved ? "resolved" : "",
-    thread.outdated ? "outdated" : "",
-    thread.pending ? "pending" : "",
-  ]->Array.filter(s => s != "")
+  let flags =
+    [
+      thread.resolved ? "resolved" : "",
+      thread.outdated ? "outdated" : "",
+      thread.pending ? "pending" : "",
+    ]->Array.filter(s => s != "")
   Attrs.focused(
     <div
       className={["inline-thread", ...flags]->Array.join(" ")}
@@ -24,7 +25,8 @@ let make = (
       onClick={ev => {
         ReactEvent.Mouse.stopPropagation(ev)
         dispatch(SetFocus({focus: Focus.Thread({index: index})}))
-      }}>
+      }}
+    >
       {thread.comments
       ->Array.map(c =>
         <div key=c.id className={"inline-comment" ++ (c.pending ? " pending" : "")}>
@@ -44,9 +46,7 @@ let make = (
       {switch composer {
       | c if c != React.null => c
       | _ =>
-        <div
-          className="inline-thread-actions"
-          onClick={ev => ReactEvent.Mouse.stopPropagation(ev)}>
+        <div className="inline-thread-actions" onClick={ev => ReactEvent.Mouse.stopPropagation(ev)}>
           <UI.Button
             label="Reply (r)"
             kind=Primary

--- a/ui/src/ui/NewReview.res
+++ b/ui/src/ui/NewReview.res
@@ -9,7 +9,11 @@ let firstRepo = (ws: Workspace.t): option<target> =>
   ws.repos[0]->Option.map(r => {repoId: r.id, base: "main", head: "worktree"})
 
 @react.component
-let make = (~workspaces: array<Workspace.t>, ~onClose: unit => unit, ~dispatch: Action.t => unit) => {
+let make = (
+  ~workspaces: array<Workspace.t>,
+  ~onClose: unit => unit,
+  ~dispatch: Action.t => unit,
+) => {
   let (title, setTitle) = React.useState(() => "")
   // Workspaces arrive after mount (listed on subscribe), so the selection is
   // resolved from props on every render; state only holds an explicit pick.
@@ -36,7 +40,8 @@ let make = (~workspaces: array<Workspace.t>, ~onClose: unit => unit, ~dispatch: 
     | _ => None
     }
   )
-  let valid = String.trim(title) != "" && Array.length(parsed) > 0 && parsed->Array.every(Option.isSome)
+  let valid =
+    String.trim(title) != "" && Array.length(parsed) > 0 && parsed->Array.every(Option.isSome)
   let submit = () =>
     if valid {
       dispatch(
@@ -51,6 +56,7 @@ let make = (~workspaces: array<Workspace.t>, ~onClose: unit => unit, ~dispatch: 
     }
   let update = (i, f: target => target) =>
     setTargets(ts => ts->Array.mapWithIndex((t, j) => i == j ? f(t) : t))
+
   {
     <form
       className="new-review panel"
@@ -58,7 +64,8 @@ let make = (~workspaces: array<Workspace.t>, ~onClose: unit => unit, ~dispatch: 
       onSubmit={ev => {
         ReactEvent.Form.preventDefault(ev)
         submit()
-      }}>
+      }}
+    >
       <UI.TextInput
         value=title
         placeholder="Title"
@@ -88,8 +95,16 @@ let make = (~workspaces: array<Workspace.t>, ~onClose: unit => unit, ~dispatch: 
             ->Option.getOr([])}
             onChange={id => update(i, t => {...t, repoId: id})}
           />
-          <UI.TextInput value=t.base placeholder="base (main, tag:v1, commit:…)" onChange={b => update(i, t => {...t, base: b})} />
-          <UI.TextInput value=t.head placeholder="head (worktree, head, branch)" onChange={h => update(i, t => {...t, head: h})} />
+          <UI.TextInput
+            value=t.base
+            placeholder="base (main, tag:v1, commit:…)"
+            onChange={b => update(i, t => {...t, base: b})}
+          />
+          <UI.TextInput
+            value=t.head
+            placeholder="head (worktree, head, branch)"
+            onChange={h => update(i, t => {...t, head: h})}
+          />
           <UI.Button
             label="−"
             kind=Ghost

--- a/ui/src/ui/Palette.res
+++ b/ui/src/ui/Palette.res
@@ -142,7 +142,10 @@ let make = (
           {React.string("Actions")}
         </span>
         <span className="palette-hint">
-          <UI.Kbd keys="tab" /> {React.string(" switch · ")} <UI.Kbd keys="esc" /> {React.string(" close")}
+          <UI.Kbd keys="tab" />
+          {React.string(" switch · ")}
+          <UI.Kbd keys="esc" />
+          {React.string(" close")}
         </span>
       </div>
       <UI.TextInput
@@ -194,7 +197,8 @@ let make = (
                       }
                       None
                     })}
-                    onClick={_ => openHit(h)}>
+                    onClick={_ => openHit(h)}
+                  >
                     <span className="hit-path">
                       {React.string(h.path ++ ":" ++ Int.toString(h.line))}
                     </span>
@@ -203,7 +207,9 @@ let make = (
                 )
                 ->React.array}
                 {c.truncated
-                  ? <li className="palette-truncated"> {React.string("more matches not shown")} </li>
+                  ? <li className="palette-truncated">
+                      {React.string("more matches not shown")}
+                    </li>
                   : React.null}
               </ul>
             | None => React.null
@@ -229,7 +235,8 @@ let make = (
               onClick={_ => {
                 dispatch(ActionPalette({open_: false}))
                 dispatch(RunCommand({command: h.command}))
-              }}>
+              }}
+            >
               <span className="hit-text"> {React.string(h.label)} </span>
               <UI.Kbd keys=h.keys />
             </li>

--- a/ui/src/ui/ReviewHeader.res
+++ b/ui/src/ui/ReviewHeader.res
@@ -15,7 +15,8 @@ module Seg = {
         className="seg"
         ?title
         ariaPressed={active ? #"true" : #"false"}
-        onClick={_ => onClick()}>
+        onClick={_ => onClick()}
+      >
         {React.string(label)}
       </button>
     active ? Attrs.withData(el, [("data-active", "true")]) : el
@@ -178,9 +179,13 @@ let make = (
           />
           <span className="header-totals">
             {React.string(Int.toString(progress.total) ++ " files · ")}
-            <span className="stat-add"> {React.string("+" ++ Int.toString(progress.additions))} </span>
+            <span className="stat-add">
+              {React.string("+" ++ Int.toString(progress.additions))}
+            </span>
             {React.string(" ")}
-            <span className="stat-del"> {React.string("−" ++ Int.toString(progress.deletions))} </span>
+            <span className="stat-del">
+              {React.string("−" ++ Int.toString(progress.deletions))}
+            </span>
           </span>
           <span className={"conn-dot conn-" ++ conn} title=conn />
         </span>

--- a/ui/src/ui/ReviewList.res
+++ b/ui/src/ui/ReviewList.res
@@ -36,7 +36,8 @@ let make = (
         onClick={_ => {
           dispatch(SetFocus({focus: Focus.ReviewList({index: i})}))
           dispatch(OpenReview({reviewId: r.id}))
-        }}>
+        }}
+      >
         <span className="review-title"> {React.string(r.title)} </span>
         {r.status == Open ? React.null : <UI.Badge text=status />}
       </li>,
@@ -45,14 +46,20 @@ let make = (
   }
   <UI.Panel
     title="Workspaces"
-    actions={<UI.Button label="refresh (R)" kind=Ghost onClick={() => dispatch(ListWorkspaces({}))} />}>
+    actions={<UI.Button
+      label="refresh (R)" kind=Ghost onClick={() => dispatch(ListWorkspaces({}))}
+    />}
+  >
     {Array.length(workspaces) == 0
       ? <UI.Empty
           text="No workspaces. Run `nits workspace add <name>` then `nits workspace attach <id> [path]`, and refresh (R)."
         />
       : workspaces
         ->Array.map(ws => {
-          let mine = reviews->Array.mapWithIndex((r, i) => (r, i))->Array.filter(((r, _)) => r.workspaceId == ws.id)
+          let mine =
+            reviews
+            ->Array.mapWithIndex((r, i) => (r, i))
+            ->Array.filter(((r, _)) => r.workspaceId == ws.id)
           <section key=ws.id className="workspace-group" ariaLabel=ws.name>
             <header className="workspace-header">
               <span className="workspace-glyph" ariaHidden=true> {React.string("▸")} </span>

--- a/ui/src/ui/Row.res
+++ b/ui/src/ui/Row.res
@@ -130,16 +130,33 @@ let make = (
     }
   | (Context({right}), Unified) => <CellView cell=right side="right" />
   | (Context({left, right}), Split) =>
-    <> <CellView cell=left side="left" /> <CellView cell=right side="right" /> </>
+    <>
+      <CellView cell=left side="left" />
+      <CellView cell=right side="right" />
+    </>
   | (Removed({left}), Unified) => <CellView cell=left side="left" />
-  | (Removed({left}), Split) => <> <CellView cell=left side="left" /> {empty("right")} </>
+  | (Removed({left}), Split) =>
+    <>
+      <CellView cell=left side="left" />
+      {empty("right")}
+    </>
   | (Added({right}), Unified) => <CellView cell=right side="right" />
-  | (Added({right}), Split) => <> {empty("left")} <CellView cell=right side="right" /> </>
+  | (Added({right}), Split) =>
+    <>
+      {empty("left")}
+      <CellView cell=right side="right" />
+    </>
   | (Modified({left, right}), Unified | Split) =>
-    <> <CellView cell=left side="left" /> <CellView cell=right side="right" /> </>
+    <>
+      <CellView cell=left side="left" />
+      <CellView cell=right side="right" />
+    </>
   }
   Attrs.withData(
-    <div className role="row" onClick={_ => onClick()}> body marker </div>,
+    <div className role="row" onClick={_ => onClick()}>
+      body
+      marker
+    </div>,
     focused
       ? [("data-focused", "true"), ("data-row-index", Int.toString(index))]
       : [("data-row-index", Int.toString(index))],

--- a/ui/src/ui/SearchBox.res
+++ b/ui/src/ui/SearchBox.res
@@ -45,7 +45,8 @@ let make = (~search: SearchView.t, ~dispatch: Action.t => unit) => {
             }
             None
           })}
-          onClick={_ => dispatch(Viewport({file: h.file, firstRow: 0, lastRow: 59}))}>
+          onClick={_ => dispatch(Viewport({file: h.file, firstRow: 0, lastRow: 59}))}
+        >
           {React.string(h.file.path)}
         </li>
       )

--- a/ui/src/ui/Stepper.res
+++ b/ui/src/ui/Stepper.res
@@ -40,7 +40,9 @@ module CommitPanel = {
         <dd>
           {commit.parents
           ->Array.map(p =>
-            <span key=p className="commit-oid"> {React.string(String.slice(p, ~start=0, ~end=8))} </span>
+            <span key=p className="commit-oid">
+              {React.string(String.slice(p, ~start=0, ~end=8))}
+            </span>
           )
           ->React.array}
         </dd>
@@ -65,8 +67,11 @@ let make = (~stepper: CommitStepper.t, ~focus: Focus.t, ~dispatch: Action.t => u
             key=c.oid
             className={"stepper-commit" ++ (isSelected ? " stepper-selected" : "")}
             onClick={_ => dispatch(SetFocus({focus: Focus.CommitStepper({index: i})}))}
-            onDoubleClick={_ => dispatch(StepCommit({selected: Some(i)}))}>
-            <span className="commit-oid"> {React.string(String.slice(c.oid, ~start=0, ~end=8))} </span>
+            onDoubleClick={_ => dispatch(StepCommit({selected: Some(i)}))}
+          >
+            <span className="commit-oid">
+              {React.string(String.slice(c.oid, ~start=0, ~end=8))}
+            </span>
             <span className="commit-subject"> {React.string(c.subject)} </span>
             <span className="commit-author"> {React.string(c.author)} </span>
           </li>,

--- a/ui/src/ui/Tabs.res
+++ b/ui/src/ui/Tabs.res
@@ -19,7 +19,8 @@ let make = (
         ariaSelected=active
         className="tab"
         title=?{Chrome.tip(chrome, command)}
-        onClick={_ => dispatch(SetTab({tab: target}))}>
+        onClick={_ => dispatch(SetTab({tab: target}))}
+      >
         {React.string(label)}
         {switch count {
         | Some(n) => <UI.Badge text={Int.toString(n)} />

--- a/ui/src/ui/Threads.res
+++ b/ui/src/ui/Threads.res
@@ -26,11 +26,12 @@ module Item = {
     ~onApply: unit => unit,
     ~onOriginal: unit => unit,
   ) => {
-    let flags = [
-      thread.resolved ? "resolved" : "",
-      thread.outdated ? "outdated" : "",
-      thread.pending ? "pending" : "",
-    ]->Array.filter(s => s != "")
+    let flags =
+      [
+        thread.resolved ? "resolved" : "",
+        thread.outdated ? "outdated" : "",
+        thread.pending ? "pending" : "",
+      ]->Array.filter(s => s != "")
     Attrs.focused(
       <li className={"thread-item " ++ flags->Array.join(" ")} onClick={_ => onSelect()}>
         <div className="thread-meta">
@@ -39,7 +40,9 @@ module Item = {
           {thread.replies > 0
             ? <UI.Badge text={Int.toString(thread.replies) ++ " replies"} />
             : React.null}
-          {thread.pending ? <span className="thread-pending"> {React.string("…")} </span> : React.null}
+          {thread.pending
+            ? <span className="thread-pending"> {React.string("…")} </span>
+            : React.null}
         </div>
         {focused
           ? <ul className="thread-comments">
@@ -51,7 +54,9 @@ module Item = {
                     <span title={Stepper.absolute(c.created)}>
                       {React.string(Stepper.relative(c.created))}
                     </span>
-                    {c.pending ? <span className="thread-pending"> {React.string("…")} </span> : React.null}
+                    {c.pending
+                      ? <span className="thread-pending"> {React.string("…")} </span>
+                      : React.null}
                   </div>
                   <div className="thread-body"> {React.string(c.body)} </div>
                 </li>

--- a/ui/src/ui/Tree.res
+++ b/ui/src/ui/Tree.res
@@ -16,7 +16,12 @@ let rec flatten = (nodes: array<TreeNode.t>, depth: int, out: array<(TreeNode.t,
   })
 
 @react.component
-let make = (~tree: TreeView.t, ~focus: Focus.t, ~home: option<string>=?, ~dispatch: Action.t => unit) => {
+let make = (
+  ~tree: TreeView.t,
+  ~focus: Focus.t,
+  ~home: option<string>=?,
+  ~dispatch: Action.t => unit,
+) => {
   let rows = []
   flatten(tree.roots, 0, rows)
   let focusedIndex = switch focus {
@@ -33,7 +38,8 @@ let make = (~tree: TreeView.t, ~focus: Focus.t, ~home: option<string>=?, ~dispat
           type_="button"
           className="tree-home"
           title="back to reviews (esc esc)"
-          onClick={_ => dispatch(CloseReview({}))}>
+          onClick={_ => dispatch(CloseReview({}))}
+        >
           {React.string("⌂ " ++ name)}
         </button>
       | None => React.string("Files")
@@ -55,7 +61,8 @@ let make = (~tree: TreeView.t, ~focus: Focus.t, ~home: option<string>=?, ~dispat
             onClick={ev => {
               onSelect(ev)
               dispatch(ToggleDir({repoId, path}))
-            }}>
+            }}
+          >
             <span className="tree-glyph"> {React.string(expanded ? "▾" : "▸")} </span>
             <span className="tree-name"> {React.string(name)} </span>
             {changedBelow > 0
@@ -66,14 +73,14 @@ let make = (~tree: TreeView.t, ~focus: Focus.t, ~home: option<string>=?, ~dispat
           <li
             key={Int.toString(i)}
             className={"tree-file" ++
-            (open_ ? " tree-open" : "") ++
-            (viewed == Viewed ? " tree-viewed-done" : "")}
+            (open_ ? " tree-open" : "") ++ (viewed == Viewed ? " tree-viewed-done" : "")}
             role="treeitem"
             style
             onClick={ev => {
               onSelect(ev)
               dispatch(Viewport({file: {repoId, path}, firstRow: 0, lastRow: 59}))
-            }}>
+            }}
+          >
             <span className="tree-glyph" />
             <span className="tree-name"> {React.string(name)} </span>
             {viewed == Viewed

--- a/ui/src/ui/UI.res
+++ b/ui/src/ui/UI.res
@@ -26,7 +26,14 @@ module Box = {
 module Panel = {
   /// A bordered region with a header; `grow` fills the remaining height.
   @react.component
-  let make = (~title: string, ~children, ~grow=false, ~actions=React.null, ~role=?, ~ariaLabel=?) => {
+  let make = (
+    ~title: string,
+    ~children,
+    ~grow=false,
+    ~actions=React.null,
+    ~role=?,
+    ~ariaLabel=?,
+  ) => {
     let className = "panel flex flex-col" ++ (grow ? " min-h-0 flex-1" : "")
     <section className ?role ?ariaLabel>
       <header className="panel-header">
@@ -48,7 +55,9 @@ module Button = {
     | Ghost => "btn btn-ghost"
     }
     // Explicit type: inside a <form> a bare <button> would submit it.
-    <button type_="button" className ?title onClick={_ => onClick()}> {React.string(label)} </button>
+    <button type_="button" className ?title onClick={_ => onClick()}>
+      {React.string(label)}
+    </button>
   }
 }
 
@@ -87,12 +96,18 @@ module Badge = {
 module Select = {
   /// A native select over `(value, label)` options.
   @react.component
-  let make = (~value: string, ~options: array<(string, string)>, ~onChange: string => unit, ~ariaLabel=?) =>
+  let make = (
+    ~value: string,
+    ~options: array<(string, string)>,
+    ~onChange: string => unit,
+    ~ariaLabel=?,
+  ) =>
     <select
       className="text-input"
       value
       ?ariaLabel
-      onChange={ev => onChange(ReactEvent.Form.target(ev)["value"])}>
+      onChange={ev => onChange(ReactEvent.Form.target(ev)["value"])}
+    >
       {options
       ->Array.map(((v, label)) => <option key=v value=v> {React.string(label)} </option>)
       ->React.array}

--- a/ui/src/view/Action.res
+++ b/ui/src/view/Action.res
@@ -42,7 +42,11 @@ type t =
   | @as("UnresolveThread") UnresolveThread({@as("thread_id") threadId: threadId})
   | @as("ApplySuggestion") ApplySuggestion({@as("comment_id") commentId: commentId})
   | @as("Viewport")
-  Viewport({file: View.FileRef.t, @as("first_row") firstRow: int, @as("last_row") lastRow: int})
+  Viewport({
+      file: View.FileRef.t,
+      @as("first_row") firstRow: int,
+      @as("last_row") lastRow: int,
+    })
   | @as("CloseFile") CloseFile({})
   | @as("ToggleDir") ToggleDir({@as("repo_id") repoId: repoId, path: @s.null option<string>})
   | @as("FileSearch") FileSearch({query: @s.null option<string>})
@@ -62,7 +66,10 @@ type t =
   | @as("CollapseParent") CollapseParent({})
   | @as("CollapseAll") CollapseAll({})
   | @as("SetRenderOpts")
-  SetRenderOpts({@as("ignore_whitespace") ignoreWhitespace: bool, @as("context_lines") contextLines: int})
+  SetRenderOpts({
+      @as("ignore_whitespace") ignoreWhitespace: bool,
+      @as("context_lines") contextLines: int,
+    })
   | @as("MarkViewed") MarkViewed({file: View.FileRef.t})
   | @as("UnmarkViewed") UnmarkViewed({file: View.FileRef.t})
   | @as("ListCommits") ListCommits({@as("repo_id") repoId: repoId})
@@ -71,9 +78,15 @@ type t =
   | @as("OpenOriginalDiff") OpenOriginalDiff({@as("thread_id") threadId: threadId})
   | @as("ExpandContext") ExpandContext({file: View.FileRef.t, full: bool})
   | @as("SetBrowseRef")
-  SetBrowseRef({@as("repo_id") repoId: repoId, @as("ref_spec") refSpec: @s.null option<Domain.RefSpec.t>})
+  SetBrowseRef({
+      @as("repo_id") repoId: repoId,
+      @as("ref_spec") refSpec: @s.null option<Domain.RefSpec.t>,
+    })
   | @as("ContentSearch")
-  ContentSearch({query: @s.null option<string>, @as("all_files") allFiles: bool})
+  ContentSearch({
+      query: @s.null option<string>,
+      @as("all_files") allFiles: bool,
+    })
   | @as("ActionPalette") ActionPalette({@as("open") open_: bool})
   | @as("RunCommand") RunCommand({command: View.Command.t})
   | @as("EnterVisual") EnterVisual({})

--- a/ui/src/view/ClientRegistry.res
+++ b/ui/src/view/ClientRegistry.res
@@ -62,6 +62,7 @@ let roundtrip = (typeName: string, json: JSON.t): result<JSON.t, string> =>
       let value = S.parseJsonOrThrow(json, schema)
       Ok(S.reverseConvertToJsonOrThrow(value, schema))
     } catch {
-    | exn => Error(JsExn.fromException(exn)->Option.flatMap(JsExn.message)->Option.getOr("unknown error"))
+    | exn =>
+      Error(JsExn.fromException(exn)->Option.flatMap(JsExn.message)->Option.getOr("unknown error"))
     }
   }

--- a/ui/src/view/View.res
+++ b/ui/src/view/View.res
@@ -485,7 +485,10 @@ module ViewPatch = {
   @schema @tag("type")
   type t =
     | @as("Connection")
-    Connection({connection: ConnectionView.t, @as("last_error") lastError: @s.null option<Rpc.RpcError.t>})
+    Connection({
+        connection: ConnectionView.t,
+        @as("last_error") lastError: @s.null option<Rpc.RpcError.t>,
+      })
     | @as("ReviewList")
     ReviewList({
         workspaces: array<Domain.Workspace.t>,
@@ -518,7 +521,11 @@ module ViewPatch = {
         chrome: array<Hint.t>,
       })
     | @as("Help") Help({help: @s.null option<HelpView.t>})
-    | @as("Draft") Draft({draft: @s.null option<Draft.t>, @as("pending_refresh") pendingRefresh: bool})
+    | @as("Draft")
+    Draft({
+        draft: @s.null option<Draft.t>,
+        @as("pending_refresh") pendingRefresh: bool,
+      })
     | @as("Search")
     Search({
         @as("content_search") contentSearch: @s.null option<ContentSearchView.t>,


### PR DESCRIPTION
CI took **8.5 minutes** against a 4.3-minute baseline because of a total cache
miss (`No cache found.`): clippy 14s→93s, nextest 85s→178s, bench 60s→144s.
After the split, the cold run measured **4m16s**.

> This description was rewritten after review. Several things it originally
> proposed were wrong and were removed rather than kept — see the threads.

## Why the cache was empty

Caches are branch-scoped — a branch reads its own or its base branch's. All the
warm caches belonged to `release-pipeline`. Once that merged, main's first CI
run failed at actionlint, so main saved nothing, and every branch cut from main
built cold.

**The fix is the split itself, not a cache setting.** `shellcheck`/`actionlint`
now live in a `scripts` job with no Rust toolchain, so a workflow-lint failure
can no longer stop the Rust jobs from publishing their caches. That is what
makes the original failure mode impossible.

I first tried `cache-on-failure: true`. That was wrong and is **not** in the
final diff: `rust-cache` skips saving on an exact-key hit
(`if (isCacheUpToDate()) return` in `save.ts`) and GitHub cache keys are
immutable, so a run failing midway would save a *partial* cache under a fresh
exact key that no later run could ever replace — strictly worse than a cold
build.

`save-if` restricts cache writes to main. Not because PR-scoped caches go
unused — later runs of the same PR do restore them, and this repository has
entries whose `last_accessed_at` postdates their creation — but because at
roughly 1.1 GiB each they are short-lived duplicates that can evict the
broadly reusable main cache under GitHub's shared per-repo quota.

## Independent jobs

The single `rust` job compiled the workspace three times in sequence — clippy's
check artifacts, nextest's dev-with-codegen, `cargo bench`'s release — and each
gate hid the next one's result.

| Job | Needs |
| --- | --- |
| `scripts` | no Rust toolchain |
| `fmt` | rustfmt only — no cache, no web bundle |
| `clippy` | compiles the tauri and web crates, so needs `web-bundle` |
| `wasm` | nothing embedded: `nits-protocol` and `nits-client-core` contain no `include_dir!` |
| `test` | `nextest --workspace`, so needs `web-bundle` too, plus the fixture freshness check |
| `ui` | pnpm only |

No explicit `key:` inputs — `rust-cache` appends `GITHUB_JOB` when
`add-job-id-key` is set, which is the default (`config.ts`). The release
workflow's existing `v0-rust-plan-…` and `v0-rust-crates-io-…` keys are that
behaviour with no `key` set.

## Benchmarks

They are a regression trigger, not a correctness gate, and cost a full
release-profile build. They move to `.github/workflows/bench.yml` and run on
**main pushes or manual dispatch only** — never in PR CI.

An earlier revision offered a `perf` label opt-in. Review found that `labeled`
is not a default `pull_request` activity type, so it never worked; and once
fixed, that any *later* label would restart an opted-in run, while
workflow-level concurrency would cancel an in-flight benchmark before the job's
`if` was evaluated. The repo owner then decided benchmarks should not run on
PRs at all, which removes that surface entirely. Job-level concurrency is kept
so back-to-back main pushes cancel the older run.

## Actions off Node 20

Every run was annotating `Node.js 20 is deprecated`. Six actions were on a major
whose `action.yml` declares `using: node20`:

```
actions/checkout            v4 -> v7   (13x)
actions/download-artifact   v4 -> v8   (5x)
actions/upload-artifact     v4 -> v7   (2x)
actions/setup-node          v4 -> v7   (2x)
pnpm/action-setup           v4 -> v6   (2x)
softprops/action-gh-release v2 -> v3   (1x)
```

`Swatinem/rust-cache@v2` already declares node24; `taiki-e/install-action` is
composite. These are major bumps, so I read each new `action.yml` rather than
assuming inputs survived — `fetch-depth`, `merge-multiple`,
`cache-dependency-path`, `generate_release_notes` and the rest all still exist,
and `ui/package.json` has no `packageManager` field for pnpm v6 to conflict
with.

## ReScript formatting

`pnpm rescript format --check` gates the `ui` job. 28 files needed formatting;
that is its own commit (`49ed7c9`), pure `rescript format` output, so the
enforcing commit carries no reformatting. 45 modules compile and all 477 tests
pass unchanged. Negative-tested rather than trusted: with a deliberately
misformatted `App.res` it exits 1, and 0 once restored.

## A note on the linter catching me

I first wrote the shared cache options as a YAML anchor with a `<<:` merge key.
`yaml.safe_load` parsed it happily; GitHub Actions does not support merge keys,
and the actionlint step added in #2 caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZsG1ZsdLgm5ZdBrdkJNxR

