### PR TITLE
release: default the AUR channel off

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ on:
         type: boolean
         default: true
       aur:
-        description: Push the AUR package
+        description: Push the AUR package (needs AUR_SSH_PRIVATE_KEY)
         type: boolean
-        default: true
+        default: false
       dry_run:
         description: Build and check everything, publish nothing
         type: boolean
@@ -442,6 +442,13 @@ jobs:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
         run: |
           set -euo pipefail
+          # Checked here rather than left to fail at `git push`: by this point
+          # crates.io and the Homebrew tap have already published, and a
+          # missing key should say so plainly.
+          if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ]; then
+            echo "::error::AUR_SSH_PRIVATE_KEY is not set — register a key on aur.archlinux.org and add the secret, or leave the aur input unticked."
+            exit 1
+          fi
           mkdir -p ~/.ssh
           printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
           chmod 600 ~/.ssh/aur

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -132,8 +132,12 @@ first, not a build target.
   workflow creates `Formula/` on first run. Users then get
   `brew install jonoprest/nits/nits`. Homebrew core needs notability (roughly
   75 stars or 30 forks) and can come later without changing anything here.
-- **AUR** — register an SSH key at <https://aur.archlinux.org/account>. The
-  first push creates `nits-bin`; the workflow handles the empty-repo case.
+- **AUR** — not set up, and the `aur` input therefore defaults to **off**.
+  To enable it, register an SSH key at <https://aur.archlinux.org/account> and
+  add `AUR_SSH_PRIVATE_KEY`; the first push creates `nits-bin`, and the
+  workflow handles the empty-repo case. The job still renders and validates
+  `PKGBUILD`/`.SRCINFO` in a dry run when ticked, so the code path does not rot
+  while the channel is unused.
 - **Signing key** — generate a dedicated key, no expiry:
   ```console
   $ gpg --batch --passphrase '<passphrase>' --quick-generate-key 'Nits <jjprest@gmail.com>' rsa4096 sign never


### PR DESCRIPTION
There is no AUR account and no `AUR_SSH_PRIVATE_KEY`. With the `aur` input defaulting to `true`, a real release would have run that job with an empty secret and failed at `git push` — **after** crates.io and the Homebrew tap had already published, which is the worst possible point to find out.

- The input defaults to `false`.
- The push step checks for the key up front and says what to do, instead of failing somewhere inside ssh.
- The job still renders and validates `PKGBUILD`/`.SRCINFO` in a dry run when ticked, so the code path doesn't rot while the channel is unused.

Re-enabling later is: register a key at aur.archlinux.org, `gh secret set AUR_SSH_PRIVATE_KEY`, tick the box. Recorded in `docs/RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZsG1ZsdLgm5ZdBrdkJNxR