### PR TITLE
release: wait out crates.io rate limits, and correct the homebrew-core note

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -57,6 +57,11 @@ treats those as separate checks, and unsigned RPMs fail the first.
 `cargo-generate-rpm`'s `--signing-key` is not used: it takes a key file but has
 no passphrase option.
 
+crates.io rate-limits *new* crates: a small burst, then one per interval. A
+first release of several new crates therefore gets partway and is refused with
+429. `publish()` waits that out rather than failing, so this needs one run
+instead of a re-run per interval.
+
 `dry_run` renders and validates every channel — formula Ruby syntax and
 per-platform checksums, PKGBUILD/.SRCINFO agreement, and the APT/YUM indexes
 and their signatures — and skips only the steps that push. Bugs in those paths
@@ -130,8 +135,7 @@ first, not a build target.
 
 - **Homebrew tap** — create `JonoPrest/homebrew-nits` (public, empty). The
   workflow creates `Formula/` on first run. Users then get
-  `brew install jonoprest/nits/nits`. Homebrew core needs notability (roughly
-  75 stars or 30 forks) and can come later without changing anything here.
+  `brew install jonoprest/nits/nits`.
 - **AUR** — not set up, and the `aur` input therefore defaults to **off**.
   To enable it, register an SSH key at <https://aur.archlinux.org/account> and
   add `AUR_SSH_PRIVATE_KEY`; the first push creates `nits-bin`, and the
@@ -155,6 +159,24 @@ thin JS shim plus one package per platform holding the binary, selected via
 `optionalDependencies` with `os`/`cpu` fields — not napi, which would only earn
 its keep if we wanted `nits-client-core` as a JavaScript *library*.
 
-**Debian and Fedora proper.** Both need a sponsoring maintainer and take months.
-The APT/YUM repo above gives people `apt install nits` today; upstreaming into
-the distributions is a separate, later errand.
+**homebrew/core**, which is what `brew install nits` without the tap prefix
+would mean. Two things gate it, and the second is not just a matter of waiting:
+
+- Notability — at least 30 forks, 30 watchers or 75 stars on the canonical
+  repository, which must also be at least 30 days old.
+- Core formulae must **build from source**; ours downloads prebuilt binaries.
+  A core formula would be a different formula: the GitHub *source* tarball (not
+  the crates.io `.crate`, which contains only the `nits` package and so cannot
+  build `nitsd`), `depends_on "rust" => :build`, and a `cargo install` per
+  binary.
+
+So this is not "the same formula, later" — budget for writing a second one.
+
+**Debian and Fedora proper.** Not a matter of patience either. Debian forbids
+vendoring: a package must build from other Debian packages with no network
+access, so every dependency crate needs to exist in the archive as
+`librust-*-dev` first. `nits` currently pulls in about 200 crates. That plus a
+sponsoring Debian Developer, an ITP bug and the NEW queue makes this a
+months-to-years project, not a release chore. The APT/YUM repo above is the
+normal answer for software in this position — Docker, the GitHub CLI and
+Tailscale all ship the same way.

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -393,19 +393,78 @@ pub fn publish(package: Releasable, dry_run: bool) -> anyhow::Result<()> {
             continue;
         }
         println!("publish {}@{}", member.name, member.version);
+        publish_one(&member.name, dry_run)?;
+    }
+    Ok(())
+}
+
+/// How many times to wait out a crates.io rate limit before giving up, and how
+/// long to wait between attempts. The new-crate limit refills roughly every ten
+/// minutes, so this covers it with margin without waiting forever on a limit
+/// that is never going to clear.
+const RATE_LIMIT_ATTEMPTS: u32 = 20;
+const RATE_LIMIT_WAIT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// `cargo publish` one crate, waiting out a crates.io rate limit rather than
+/// failing on it.
+///
+/// crates.io allows a small burst of *new* crates and then one per interval, so
+/// a first release of several new crates gets partway and is refused with 429.
+/// Nothing is wrong with the package at that point — the only correct response
+/// is to wait — but treating it as fatal means a human re-running the job once
+/// per interval.
+fn publish_one(name: &str, dry_run: bool) -> anyhow::Result<()> {
+    for attempt in 1..=RATE_LIMIT_ATTEMPTS {
         let mut cmd = Command::new("cargo");
-        cmd.args(["publish", "--package", &member.name, "--locked"]);
+        cmd.args(["publish", "--package", name, "--locked"]);
         if dry_run {
             cmd.arg("--dry-run");
         }
-        let status = cmd
-            .status()
-            .with_context(|| format!("running `cargo publish -p {}`", member.name))?;
-        if !status.success() {
-            bail!("`cargo publish -p {}` failed", member.name);
+        let out = cmd
+            .output()
+            .with_context(|| format!("running `cargo publish -p {name}`"))?;
+
+        // cargo writes progress to stderr; relay both so the job log still
+        // reads like a normal publish.
+        print!("{}", String::from_utf8_lossy(&out.stdout));
+        eprint!("{}", String::from_utf8_lossy(&out.stderr));
+        if out.status.success() {
+            return Ok(());
         }
+
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let Some(after) = rate_limited_until(&stderr) else {
+            bail!("`cargo publish -p {name}` failed");
+        };
+        if attempt == RATE_LIMIT_ATTEMPTS {
+            bail!(
+                "`cargo publish -p {name}` is still rate limited after {attempt} attempts; \
+                 crates.io last said to try again after {after}"
+            );
+        }
+        println!(
+            "rate limited on {name}: crates.io says try again after {after} \
+             — waiting {}s (attempt {attempt}/{RATE_LIMIT_ATTEMPTS})",
+            RATE_LIMIT_WAIT.as_secs()
+        );
+        std::thread::sleep(RATE_LIMIT_WAIT);
     }
     Ok(())
+}
+
+/// The time crates.io told us to retry after, if this failure was a rate limit.
+///
+/// The message is: `the remote server responded with an error (status 429 Too
+/// Many Requests): You have published too many new crates in a short period of
+/// time. Please try again after Wed, 02 Sep 2026 11:46:21 GMT and see …`. We
+/// only report the timestamp — parsing it to sleep exactly that long would need
+/// a date library for no benefit over polling.
+fn rate_limited_until(stderr: &str) -> Option<&str> {
+    if !stderr.contains("429") {
+        return None;
+    }
+    let after = stderr.split("Please try again after ").nth(1)?;
+    Some(after.split(" and see").next().unwrap_or(after).trim())
 }
 
 /// The first publishable workspace dependency of `member` that crates.io does
@@ -568,6 +627,30 @@ mod tests {
         git(dir, &["commit", "-qam", "two"]);
         // The tag now names other code: a real collision.
         assert_eq!(tag_state(dir, "v1").expect("state"), TagState::Elsewhere);
+    }
+
+    #[test]
+    fn a_rate_limit_is_recognised_and_its_retry_time_extracted() {
+        let stderr = "\
+error: failed to publish nits-client-host v0.1.0 to registry at https://crates.io
+  the remote server responded with an error (status 429 Too Many Requests): You \
+have published too many new crates in a short period of time. Please try again \
+after Wed, 02 Sep 2026 11:46:21 GMT and see https://crates.io/docs/rate-limits \
+for more details.";
+        assert_eq!(
+            rate_limited_until(stderr),
+            Some("Wed, 02 Sep 2026 11:46:21 GMT")
+        );
+    }
+
+    #[test]
+    fn other_failures_are_not_treated_as_rate_limits() {
+        // A verified email address is required — retrying this forever would
+        // turn a clear error into a twenty-minute hang.
+        let stderr = "the remote server responded with an error (status 400 Bad \
+Request): A verified email address is required to publish crates to crates.io.";
+        assert_eq!(rate_limited_until(stderr), None);
+        assert_eq!(rate_limited_until("some unrelated build failure"), None);
     }
 
     #[test]


### PR DESCRIPTION
Two follow-ups from shipping 0.1.0.

## crates.io rate limits are no longer fatal

Publishing 0.1.0 took four attempts: one for a verified-email requirement, then three for crates.io's new-crate rate limit (a small burst, then one per interval). `publish()` treated the 429 as fatal, so a human re-ran the job once per slot:

```
429 Too Many Requests: You have published too many new crates in a short
period of time. Please try again after Wed, 02 Sep 2026 11:46:21 GMT
```

It now recognises the 429, prints the retry time crates.io supplies, and waits — so a first release of several new crates completes in one run.

The detector matches 429 **specifically**, because the other failure must stay fatal: a 400 `A verified email address is required` retried for twenty minutes turns a clear error into a hang. Both are tested.

I said earlier this would bite the next new binary. That was overstated — a `nits-mcp` release adds only one new crate, and the burst will have refilled. It is still worth removing a failure mode whose only correct response is to wait.

## Two corrections to RELEASING.md

**homebrew/core.** I wrote that it "can come later without changing anything here." Wrong: core formulae must build from source, and ours downloads prebuilt binaries. Core needs a *second* formula, built from the GitHub source tarball — not the crates.io `.crate`, which contains only the `nits` package and therefore cannot build `nitsd`. Notability (30 forks / 30 watchers / 75 stars, repo ≥30 days old) is the lesser of the two obstacles.

**Debian.** The note said it needs a sponsor and takes months. The real blocker is that Debian forbids vendoring — a package must build from other Debian packages with no network access, so every dependency crate must exist in the archive as `librust-*-dev` first. `nits` pulls in ~200 crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZsG1ZsdLgm5ZdBrdkJNxR