### PR TITLE
Add arrow-key aliases for split diff sides

### DIFF
--- a/crates/nits-client-core/src/keymap.rs
+++ b/crates/nits-client-core/src/keymap.rs
@@ -154,9 +154,9 @@ pub enum Command {
     ExpandDown,
     /// Comment on the open file (`z c`, file-level anchor).
     CommentOnFile,
-    /// Target the removed (left) half of the focused row (`h`).
+    /// Target the removed (left) half of the focused row (`h`/Left).
     SideBase,
-    /// Target the added (right) half of the focused row (`l`).
+    /// Target the added (right) half of the focused row (`l`/Right).
     SideHead,
     /// Put the focused row in the middle of the viewport (`z z`).
     CenterView,
@@ -635,9 +635,12 @@ impl Keymap {
             b(X::Diff, keys!("z u"), C::ExpandUp, false),
             b(X::Diff, keys!("z d"), C::ExpandDown, false),
             b(X::Diff, keys!("z c"), C::CommentOnFile, false),
-            // A modified row is two commentable cells: h/l pick which.
+            // A modified row is two commentable cells: h/l are canonical;
+            // the arrows are non-primary aliases of the same commands.
             b(X::Diff, keys!("h"), C::SideBase, false),
             b(X::Diff, keys!("l"), C::SideHead, false),
+            b(X::Diff, keys!("left"), C::SideBase, false),
+            b(X::Diff, keys!("right"), C::SideHead, false),
             // The scroll family moves the view, not the cursor.
             b(X::Diff, keys!("z z"), C::CenterView, false),
             b(X::Diff, keys!("z t"), C::ViewTop, false),

--- a/crates/nits-client-core/tests/keys.rs
+++ b/crates/nits-client-core/tests/keys.rs
@@ -1191,9 +1191,9 @@ fn comment_on_a_modified_row_anchors_to_the_focused_side() {
     assert_eq!(blob_oid, blob(11));
     assert_eq!(lines.start().get(), 5);
 
-    // `h` moves onto the red half of the same row: same row, base blob.
+    // Left is an alias of `h`: same row, base blob.
     let mut core = on_row(MODIFIED_ROW, Side::Head);
-    press(&mut core, "h").unwrap();
+    press(&mut core, "left").unwrap();
     assert_eq!(
         core.view().focus,
         Focus::Diff {
@@ -1217,26 +1217,58 @@ fn comment_on_a_modified_row_anchors_to_the_focused_side() {
 }
 
 #[test]
+fn vim_and_arrow_bindings_select_the_same_side_of_a_modified_row() {
+    for (key, from, to, command) in [
+        ("h", Side::Head, Side::Base, Command::SideBase),
+        ("left", Side::Head, Side::Base, Command::SideBase),
+        ("l", Side::Base, Side::Head, Command::SideHead),
+        ("right", Side::Base, Side::Head, Command::SideHead),
+    ] {
+        let mut core = on_row(MODIFIED_ROW, from);
+        press(&mut core, key).unwrap();
+        assert_eq!(
+            core.view().focus,
+            Focus::Diff {
+                row: MODIFIED_ROW,
+                side: to
+            },
+            "{key}"
+        );
+        assert_eq!(
+            core.view().last_key.as_ref().and_then(|last| last.command),
+            Some(command),
+            "{key} must resolve to the typed side-selection command"
+        );
+    }
+}
+
+#[test]
 fn a_row_with_one_cell_has_no_other_side_to_move_to() {
     // An added row has no base cell, a removed row no head cell.
-    let mut core = on_row(ADDED_ROW, Side::Head);
-    assert!(press(&mut core, "h").is_err());
-    assert_eq!(
-        core.view().focus,
-        Focus::Diff {
-            row: ADDED_ROW,
-            side: Side::Head
-        }
-    );
-    let mut core = on_row(REMOVED_ROW, Side::Base);
-    assert!(press(&mut core, "l").is_err());
-    assert_eq!(
-        core.view().focus,
-        Focus::Diff {
-            row: REMOVED_ROW,
-            side: Side::Base
-        }
-    );
+    for key in ["h", "left"] {
+        let mut core = on_row(ADDED_ROW, Side::Head);
+        assert!(press(&mut core, key).is_err(), "{key}");
+        assert_eq!(
+            core.view().focus,
+            Focus::Diff {
+                row: ADDED_ROW,
+                side: Side::Head
+            },
+            "{key}"
+        );
+    }
+    for key in ["l", "right"] {
+        let mut core = on_row(REMOVED_ROW, Side::Base);
+        assert!(press(&mut core, key).is_err(), "{key}");
+        assert_eq!(
+            core.view().focus,
+            Focus::Diff {
+                row: REMOVED_ROW,
+                side: Side::Base
+            },
+            "{key}"
+        );
+    }
 }
 
 /// The rows of `chunk()`: the expander sits at index 148, between the

--- a/crates/nits-client-core/tests/snapshots/snapshots__after_open.snap
+++ b/crates/nits-client-core/tests/snapshots/snapshots__after_open.snap
@@ -1302,6 +1302,16 @@ expression: core.view()
       "label": "target added side"
     },
     {
+      "keys": "left",
+      "command": "SideBase",
+      "label": "target removed side"
+    },
+    {
+      "keys": "right",
+      "command": "SideHead",
+      "label": "target added side"
+    },
+    {
       "keys": "z z",
       "command": "CenterView",
       "label": "centre the view"

--- a/crates/nits-client-core/tests/snapshots/snapshots__file_open.snap
+++ b/crates/nits-client-core/tests/snapshots/snapshots__file_open.snap
@@ -1302,6 +1302,16 @@ expression: core.view()
       "label": "target added side"
     },
     {
+      "keys": "left",
+      "command": "SideBase",
+      "label": "target removed side"
+    },
+    {
+      "keys": "right",
+      "command": "SideHead",
+      "label": "target added side"
+    },
+    {
       "keys": "z z",
       "command": "CenterView",
       "label": "centre the view"

--- a/docs/UI-DESIGN.md
+++ b/docs/UI-DESIGN.md
@@ -253,8 +253,9 @@ Everything explicitly asked for, so no shell or rewrite loses them.
 - ✓ A modified row is TWO comment targets, not one: the removed (red)
   cell anchors to base, the added (green) cell to head. The focus
   carries the side (`Focus::Diff { row, side }`); `h`/`l` move between
-  the halves, the mouse hit-tests the cell it is over, and a drag or
-  Visual selection keeps the side it started on. A thread's marker hangs
+  the halves, with Left/Right as aliases. The mouse hit-tests the cell it
+  is over, and a drag or Visual selection keeps the side it started on. A
+  thread's marker hangs
   on the cell its anchor names.
 - ✓ The viewport follows the focused row: a motion that would take the
   cursor past the edge scrolls by as little as it can, keeping 3 rows of

--- a/ui/__tests__/Components_test.res
+++ b/ui/__tests__/Components_test.res
@@ -701,6 +701,21 @@ if (!globalThis.Element.prototype.scrollIntoView) {
 }
 `)
 
+module SideFocusHarness = {
+  @react.component
+  let make = (~diff: View.DiffView.t) => {
+    let (focus, setFocus) = React.useState((): View.Focus.t => Diff({row: 121, side: Head}))
+    let dispatch = action =>
+      switch action {
+      | Action.SetFocus({focus}) => setFocus(_ => focus)
+      | _ => ()
+      }
+    <FileDiff
+      diff layout=Split focus threads=[] draft=None pendingRefresh=false isOpen=true dispatch
+    />
+  }
+}
+
 describe("Row sides", () => {
   // The fixture row is modified (two cells) and carries a base-anchored
   // thread; a removed row below it gives the drag a second base line.
@@ -772,6 +787,28 @@ describe("Row sides", () => {
     expect(dispatch)->toHaveBeenLastCalledWith(
       Action.SetFocus({focus: Diff({row: 121, side: Head})}),
     )
+  })
+
+  test("split-mode focus styling follows side-selection interactions", () => {
+    let {container} = render(<SideFocusHarness diff={diff()} />)
+    let row = () =>
+      Element.querySelector(container, "[data-row-index=\"121\"]")
+      ->Nullable.toOption
+      ->Option.getExn
+    let left = () => Element.querySelector(row(), ".cell-left")->Nullable.toOption->Option.getExn
+    let right = () => Element.querySelector(row(), ".cell-right")->Nullable.toOption->Option.getExn
+
+    expect(Element.className(right()))->toContain("cell-focused")
+    expect(Element.className(left()))->not_->toContain("cell-focused")
+    FireEvent.click(left())
+    expect(Element.className(left()))->toContain("cell-focused")
+    expect(Element.className(right()))->not_->toContain("cell-focused")
+    expect(Element.getAttribute(row(), "data-side"))->toEqual(Nullable.make("Base"))
+
+    FireEvent.click(right())
+    expect(Element.className(right()))->toContain("cell-focused")
+    expect(Element.className(left()))->not_->toContain("cell-focused")
+    expect(Element.getAttribute(row(), "data-side"))->toEqual(Nullable.make("Head"))
   })
 
   test("dragging down the removed side comments on base lines", () => {


### PR DESCRIPTION
Fixes #30

## Summary

- add Left and Right as typed aliases for selecting the base and head sides of split diff rows
- preserve h/l as the canonical bindings
- cover paired and single-sided rows, comment anchoring, focus styling, advertised bindings, and design documentation

## Validation

- cargo test -p nits-client-core -p nits-client-host
- cargo clippy -p nits-client-core -p nits-client-host --all-targets -- -D warnings
- cargo check -p nits-protocol -p nits-client-core --target wasm32-unknown-unknown
- cargo fmt --all -- --check
- pnpm rescript
- pnpm test
- pnpm vite build

— gpt-5.6-sol via Codex (author)