### PR TITLE
Expose every contextual shortcut in help

### DIFF
--- a/crates/nits-client-core/src/keymap.rs
+++ b/crates/nits-client-core/src/keymap.rs
@@ -951,7 +951,11 @@ impl Keymap {
                     .map(ToString::to_string)
                     .collect::<Vec<_>>()
                     .join(" ");
-                if !out.iter().any(|h| h.keys == rest) {
+                // The same continuation may deliberately name more than
+                // one command when an override conflicts. Keep both so the
+                // which-key surface reports the collision instead of
+                // silently making one configured command undiscoverable.
+                if !out.iter().any(|h| h.keys == rest && h.command == b.command) {
                     out.push(Hint {
                         keys: rest,
                         command: b.command,
@@ -1343,5 +1347,139 @@ mod tests {
             assert!(hints.iter().all(|h| !h.label.is_empty()));
             assert_eq!(hints.last().unwrap().command, Command::ToggleHelp);
         }
+    }
+
+    #[test]
+    fn help_and_every_pending_prefix_are_exhaustively_derived_from_bindings() {
+        let map = Keymap::default_table();
+        for context in Context::iter() {
+            let help = map.help(context);
+            let contexts = if context == Context::Global {
+                vec![Context::Global]
+            } else {
+                vec![context, Context::Global]
+            };
+            assert_eq!(
+                help.groups.iter().map(|g| g.context).collect::<Vec<_>>(),
+                contexts,
+                "help groups for {context}"
+            );
+            for group in &help.groups {
+                let bindings = map
+                    .bindings()
+                    .iter()
+                    .filter(|binding| binding.context == group.context)
+                    .collect::<Vec<_>>();
+                assert_eq!(group.entries.len(), bindings.len(), "help for {context}");
+                for (entry, binding) in group.entries.iter().zip(bindings) {
+                    assert_eq!(entry.keys, binding.keys.to_string());
+                    assert_eq!(entry.command, binding.command);
+                    assert_eq!(entry.label, label(binding.command));
+                    assert_eq!(entry.primary, binding.primary);
+                    assert_eq!(
+                        entry.overridden,
+                        map.is_overridden(binding.context, binding.command)
+                    );
+                }
+            }
+
+            let mut prefixes = map
+                .applicable(context)
+                .flat_map(|binding| {
+                    (1..binding.keys.chords().len())
+                        .map(|len| binding.keys.chords()[..len].to_vec())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+            prefixes.sort_by_key(|prefix| {
+                prefix
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            });
+            prefixes.dedup();
+            for prefix in prefixes {
+                let expected = map
+                    .applicable(context)
+                    .filter(|binding| {
+                        binding.keys.chords().len() > prefix.len()
+                            && binding.keys.starts_with(&prefix)
+                    })
+                    .map(|binding| Hint {
+                        keys: binding.keys.chords()[prefix.len()..]
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                        command: binding.command,
+                        label: label(binding.command).to_owned(),
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    map.pending_hints(context, &prefix),
+                    expected,
+                    "pending hints for {context} after {}",
+                    prefix
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn overridden_conflicting_continuations_remain_discoverable() {
+        let map = Keymap::with_overrides(&Overrides {
+            bindings: vec![
+                Override {
+                    context: Context::Diff,
+                    command: Command::ExpandUp,
+                    keys: Some(keys!("z x")),
+                    primary: false,
+                },
+                Override {
+                    context: Context::Diff,
+                    command: Command::ExpandDown,
+                    keys: Some(keys!("z x")),
+                    primary: false,
+                },
+            ],
+        });
+        let pending = map.pending_hints(Context::Diff, &[KeyChord::char('z')]);
+        assert!(
+            pending
+                .iter()
+                .any(|hint| hint.keys == "x" && hint.command == Command::ExpandUp)
+        );
+        assert!(
+            pending
+                .iter()
+                .any(|hint| hint.keys == "x" && hint.command == Command::ExpandDown)
+        );
+
+        let help = map.help(Context::Diff);
+        let diff = help
+            .groups
+            .iter()
+            .find(|group| group.context == Context::Diff)
+            .unwrap();
+        for command in [Command::ExpandUp, Command::ExpandDown] {
+            let entry = diff
+                .entries
+                .iter()
+                .find(|entry| entry.command == command)
+                .unwrap();
+            assert_eq!(entry.keys, "z x");
+            assert!(entry.overridden);
+        }
+        assert!(help.conflicts.iter().any(|conflict| {
+            conflict.context == Context::Diff
+                && conflict.keys.to_string() == "z x"
+                && conflict.commands.contains(&Command::ExpandUp)
+                && conflict.commands.contains(&Command::ExpandDown)
+        }));
     }
 }

--- a/crates/nits-client-core/src/lib.rs
+++ b/crates/nits-client-core/src/lib.rs
@@ -558,7 +558,10 @@ pub struct ClientCore {
     /// Chords of a sequence in progress, and when it started.
     chords: Vec<KeyChord>,
     chord_started: Millis,
-    help_open: bool,
+    /// Context whose bindings the open help overlay describes. `None`
+    /// means help is closed; retaining the origin keeps moving focus into
+    /// `Help` from replacing the commands the reader asked to inspect.
+    help_context: Option<keymap::Context>,
     /// Focus to return to when the composer or help closes.
     focus_return: Option<Focus>,
     /// `SetScope { ByCommit }` is waiting for its `ListCommits` answer.
@@ -628,7 +631,7 @@ impl ClientCore {
             keymap: Keymap::default_table(),
             chords: Vec::new(),
             chord_started: 0,
-            help_open: false,
+            help_context: None,
             focus_return: None,
             by_commit_pending: false,
             file_collapse: std::collections::BTreeMap::new(),
@@ -1052,7 +1055,7 @@ impl ClientCore {
             self.view.leader = leader;
             sections.push(ViewSection::Hints);
         }
-        let help = self.help_open.then(|| self.keymap.help(focus.context()));
+        let help = self.help_context.map(|context| self.keymap.help(context));
         if help != self.view.help {
             self.view.help = help;
             sections.push(ViewSection::Help);
@@ -2126,11 +2129,11 @@ impl ClientCore {
                 Ok(effects)
             }
             Action::ToggleHelp => {
-                if self.help_open {
-                    self.help_open = false;
+                if self.help_context.is_some() {
+                    self.help_context = None;
                     self.leave();
                 } else {
-                    self.help_open = true;
+                    self.help_context = Some(self.view.focus.context());
                     self.enter(Focus::Help);
                 }
                 Ok(vec![render(&[ViewSection::Help, ViewSection::Focus])])
@@ -2463,7 +2466,7 @@ impl ClientCore {
         self.pending.clear();
         self.stepper = None;
         self.focus_return = None;
-        self.help_open = false;
+        self.help_context = None;
         self.by_commit_pending = false;
         self.browse = None;
         self.visual_anchor = None;

--- a/crates/nits-client-core/tests/keys.rs
+++ b/crates/nits-client-core/tests/keys.rs
@@ -856,6 +856,32 @@ fn sequences_resolve_and_expire() {
 }
 
 #[test]
+fn pending_diff_expand_group_lists_every_continuation() {
+    let mut core = ready();
+    assert!(matches!(core.view().focus, Focus::Diff { .. }));
+    core.handle(Input::Key(KeyChord::char('z'))).unwrap();
+    assert_eq!(core.view().pending_keys, "z");
+    assert_eq!(core.view().pending_label.as_deref(), Some("Expand/scroll"));
+    assert_eq!(core.view().hints.len(), 6);
+    for (keys, command) in [
+        ("u", Command::ExpandUp),
+        ("d", Command::ExpandDown),
+        ("c", Command::CommentOnFile),
+        ("z", Command::CenterView),
+        ("t", Command::ViewTop),
+        ("b", Command::ViewBottom),
+    ] {
+        assert!(
+            core.view()
+                .hints
+                .iter()
+                .any(|hint| hint.keys == keys && hint.command == command),
+            "pending z group omitted {keys}"
+        );
+    }
+}
+
+#[test]
 fn diff_focus_scrolls_the_viewport_and_navigates_hunks_and_comments() {
     let mut core = ready();
     core.handle(Input::User(Action::Viewport {
@@ -965,13 +991,50 @@ fn help_and_hints_follow_focus_and_help_is_never_empty() {
     assert!(rendered(&effects).contains(&ViewSection::Help));
     assert_eq!(core.view().focus, Focus::Help);
     let help = core.view().help.as_ref().unwrap();
-    assert_eq!(help.groups[0].context, Context::Help);
+    assert_eq!(
+        help.groups[0].context,
+        Context::Tree,
+        "help describes the context focused when it opened"
+    );
     assert!(help.conflicts.is_empty());
     press(&mut core, "?").unwrap();
     assert!(core.view().help.is_none());
     assert_eq!(core.view().focus, Focus::Tree { index: 0 });
     // Hints changed with the context and back.
     assert_eq!(core.view().hints, hints_tree);
+
+    core.handle(Input::User(Action::SetFocus {
+        focus: Focus::Diff {
+            row: 0,
+            side: Side::Head,
+        },
+    }))
+    .unwrap();
+    press(&mut core, "?").unwrap();
+    let diff_help = &core.view().help.as_ref().unwrap().groups[0];
+    assert_eq!(diff_help.context, Context::Diff);
+    for (keys, command) in [
+        ("z u", Command::ExpandUp),
+        ("z d", Command::ExpandDown),
+        ("z c", Command::CommentOnFile),
+        ("z z", Command::CenterView),
+        ("z t", Command::ViewTop),
+        ("z b", Command::ViewBottom),
+    ] {
+        assert!(
+            diff_help
+                .entries
+                .iter()
+                .any(|entry| entry.keys == keys && entry.command == command),
+            "Diff help omitted {keys}"
+        );
+    }
+    press(&mut core, "?").unwrap();
+    core.handle(Input::User(Action::SetFocus {
+        focus: Focus::Tree { index: 0 },
+    }))
+    .unwrap();
+
     // A keys config from the KV re-derives the hints: `open` rebinds to
     // `o` across normal mode.
     let mut normal = std::collections::BTreeMap::new();

--- a/crates/nits-client-core/tests/snapshots/snapshots__pending_reply_and_help.snap
+++ b/crates/nits-client-core/tests/snapshots/snapshots__pending_reply_and_help.snap
@@ -1168,34 +1168,83 @@ expression: core.view()
   "help": {
     "groups": [
       {
-        "context": "Help",
+        "context": "Thread",
         "entries": [
           {
             "keys": "j",
             "command": "MoveDown",
             "label": "down",
-            "primary": false,
+            "primary": true,
             "overridden": false
           },
           {
             "keys": "k",
             "command": "MoveUp",
             "label": "up",
+            "primary": true,
+            "overridden": false
+          },
+          {
+            "keys": "down",
+            "command": "MoveDown",
+            "label": "down",
             "primary": false,
             "overridden": false
           },
           {
-            "keys": "?",
-            "command": "ToggleHelp",
-            "label": "help",
+            "keys": "up",
+            "command": "MoveUp",
+            "label": "up",
+            "primary": false,
+            "overridden": false
+          },
+          {
+            "keys": "g g",
+            "command": "GoTop",
+            "label": "top",
+            "primary": false,
+            "overridden": false
+          },
+          {
+            "keys": "G",
+            "command": "GoBottom",
+            "label": "bottom",
+            "primary": false,
+            "overridden": false
+          },
+          {
+            "keys": "enter",
+            "command": "Open",
+            "label": "open",
             "primary": true,
             "overridden": false
           },
           {
-            "keys": "esc",
-            "command": "Back",
-            "label": "back",
+            "keys": "r",
+            "command": "Reply",
+            "label": "reply",
             "primary": true,
+            "overridden": false
+          },
+          {
+            "keys": "x",
+            "command": "ToggleResolved",
+            "label": "resolve",
+            "primary": true,
+            "overridden": false
+          },
+          {
+            "keys": "d",
+            "command": "Delete",
+            "label": "delete",
+            "primary": false,
+            "overridden": false
+          },
+          {
+            "keys": "a",
+            "command": "ApplySuggestion",
+            "label": "apply suggestion",
+            "primary": false,
             "overridden": false
           }
         ]

--- a/ui/__tests__/Components_test.res
+++ b/ui/__tests__/Components_test.res
@@ -173,6 +173,80 @@ describe("HintBar", () => {
     expect(Screen.getByText("g"))->toBeTruthy
     expect(Screen.getByText("split layout"))->toBeTruthy
   })
+
+  test("renders every continuation while the Diff z group is pending", () => {
+    let hints: array<View.Hint.t> = [
+      {keys: "u", command: ExpandUp, label: "expand up"},
+      {keys: "d", command: ExpandDown, label: "expand down"},
+      {keys: "c", command: CommentOnFile, label: "comment on file"},
+      {keys: "z", command: CenterView, label: "centre the view"},
+      {keys: "t", command: ViewTop, label: "row to top"},
+      {keys: "b", command: ViewBottom, label: "row to bottom"},
+    ]
+    let {container} = render(
+      <HintBar
+        hints
+        pendingKeys="z"
+        pendingLabel="Expand/scroll"
+        focusName="DIFF"
+        connection={Subscribed({})}
+        progress={{viewed: 0, changedSinceViewed: 0, total: 0, additions: 0, deletions: 0}}
+      />,
+    )
+    expect(Element.querySelector(container, ".hint-bar-pending"))->not_->toBeNull
+    expect(Screen.getByText("Expand/scroll"))->toBeTruthy
+    [
+      "expand up",
+      "expand down",
+      "comment on file",
+      "centre the view",
+      "row to top",
+      "row to bottom",
+    ]->Array.forEach(label => expect(Screen.getByText(label))->toBeTruthy)
+    ["u", "d", "c", "t", "b"]->Array.forEach(
+      key => expect(Array.length(Screen.queryAllByText(key)))->toBe(1),
+    )
+  })
+})
+
+describe("HelpOverlay", () => {
+  test("renders every full Diff z chord plus Global, overrides, and conflicts", () => {
+    let entry = (keys, command, label, overridden): View.HelpEntry.t => {
+      keys,
+      command,
+      label,
+      primary: false,
+      overridden,
+    }
+    let help: View.HelpView.t = {
+      groups: [
+        {
+          context: Diff,
+          entries: [
+            entry("z u", ExpandUp, "expand up", true),
+            entry("z d", ExpandDown, "expand down", false),
+            entry("z c", CommentOnFile, "comment on file", false),
+            entry("z z", CenterView, "centre the view", false),
+            entry("z t", ViewTop, "row to top", false),
+            entry("z b", ViewBottom, "row to bottom", false),
+          ],
+        },
+        {
+          context: Global,
+          entries: [entry("?", ToggleHelp, "help", false)],
+        },
+      ],
+      conflicts: [{context: Diff, keys: "z u", commands: [ExpandUp, ExpandDown]}],
+    }
+    let {container} = render(<HelpOverlay help dispatch={_ => ()} />)
+    ["z u", "z d", "z c", "z z", "z t", "z b", "?"]->Array.forEach(
+      keys => expect(Array.length(Screen.queryAllByText(keys)))->toBe(keys == "z u" ? 2 : 1),
+    )
+    expect(Screen.getByText("Diff"))->toBeTruthy
+    expect(Screen.getByText("Global"))->toBeTruthy
+    expect(Element.querySelector(container, ".help-overridden"))->not_->toBeNull
+    expect(Element.querySelector(container, ".help-conflicts"))->not_->toBeNull
+  })
 })
 
 describe("Tree", () => {


### PR DESCRIPTION
Fixes #36

Stacked on #39.

## Summary

- derive complete contextual help and pending-prefix hints from the typed keymap
- retain the context where help was opened so grouped shortcuts such as z u and z d remain visible
- preserve conflicting commands that share a continuation and surface overrides/conflicts
- add exhaustive core coverage for every context, help group, binding prefix, and the full Diff z group

## Validation

- cargo test -p nits-client-core
- cargo clippy -p nits-client-core --all-targets -- -D warnings
- cargo check -p nits-client-core --target wasm32-unknown-unknown
- cargo fmt --all -- --check
- pnpm rescript format --check
- pnpm rescript
- pnpm test
- pnpm vite build

— gpt-5.6-sol via Codex (author)